### PR TITLE
Exclude shopping/store lists from due date requirement

### DIFF
--- a/agent-context/INSTRUCTIONS.md
+++ b/agent-context/INSTRUCTIONS.md
@@ -31,7 +31,7 @@ Do NOT create Todoist tasks for software project work (those go to GitHub Issues
 Rules:
 - Only create a task when the transcript contains a clear, actionable personal to-do
 - Be conservative — vague thoughts are not tasks
-- ALWAYS set `due_string`. Use the date mentioned, or "today" if none
+- Set `due_string` using the date mentioned, or "today" if none — EXCEPT for shopping lists or store-related lists (e.g., grocery store, hardware store), which should have NO due date
 - ALWAYS end the `description` with "Created by jpOS". Add brief context before that line if useful
 
 ## Active Projects Maintenance


### PR DESCRIPTION
Shopping lists and store-related lists (grocery, hardware, etc.) no longer
get automatic due dates when created via Todoist. Other personal tasks
still default to "today" if no date is mentioned.

https://claude.ai/code/session_015yu36CPXXUp4ib2HZwph6N