### PR TITLE
fix: Add America/New_York timezone to voice note timestamp conversion

### DIFF
--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -123,6 +123,7 @@ export async function createApiServer() {
       // Format timestamp from createdAt
       const timestamp = createdAt
         ? new Date(createdAt).toLocaleTimeString("en-US", {
+            timeZone: "America/New_York",
             hour: "2-digit",
             minute: "2-digit",
             hour12: true,


### PR DESCRIPTION
Fixes #6

Voice note timestamps were being converted without specifying timezone, causing them to default to UTC instead of the configured America/New_York timezone.

## Changes
- Added `timeZone: "America/New_York"` option to `toLocaleTimeString()` in `src/interfaces/api.ts`
- Matches the implementation in `src/obsidian.ts` `getTimeString()` function

Generated with [Claude Code](https://claude.ai/code)