### PR TITLE
Add mem0 + Qdrant long-term memory layer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,13 +31,47 @@ CLI tools (invoked via Bash) are more token-efficient than MCP tool definitions 
 
 ## Architecture
 
-- `src/agent.ts` - Agent SDK wrapper with session management
+- `src/agent.ts` - Agent SDK wrapper with session management + auto-recall step
 - `src/prompt.ts` - Builds system prompt from repo system files + vault memory
-- `src/memory.ts` - Memory file reader (durable memory, weekly digests, daily logs)
+- `src/memory.ts` - **(legacy, being phased out)** File-based reader for vault digests/daily logs
+- `src/memory-store.ts` - **mem0 + Qdrant memory store.** Primary memory layer.
 - `src/interfaces/telegram.ts` - Telegram bot (grammy)
-- `src/interfaces/api.ts` - HTTP API (Fastify)
+- `src/interfaces/api.ts` - HTTP API (Fastify) + memory inspection endpoints
+- `src/mcp/memory.ts` - Memory MCP server (`remember`, `recall`, `list_memories`, `forget`, `update_memory`)
 - `src/mcp/todoist.ts` - Todoist MCP server
 - `src/obsidian.ts` - Git operations for Obsidian vault
+
+## Memory layer (mem0 + Qdrant)
+
+The agent's long-term memory uses [mem0](https://github.com/mem0ai/mem0) backed by a self-hosted Qdrant vector store on Fly.
+
+- **Vector store:** Qdrant — separate Fly app `jpos-qdrant`, reachable internally at `http://jpos-qdrant.internal:6333`. See `jpos-qdrant/README.md` for setup.
+- **LLM (for fact extraction + dedup):** `gpt-4.1-nano` via OpenAI (cheap; ~$0.001/write). Configurable via `MEM0_LLM_MODEL`.
+- **Embeddings:** `text-embedding-3-small` via OpenAI. Configurable via `MEM0_EMBEDDING_MODEL`.
+- **History DB:** SQLite at `/data/mem0-history.db` on Fly (tracks add/update/delete events).
+- **Single-user:** all memories written under `userId = "jp"`; use `metadata.source` (voice-note, telegram, daily-prep, etc.) to distinguish origin.
+
+### Auto-recall
+
+`runAgent()` does a top-K (default 5) mem0 search on the incoming user message and injects results into the system prompt under a `# Recalled Memories` section. Fail-graceful: if Qdrant is down, the agent still responds without recalled context. Opt out by passing `autoRecall: false` (used for all cron jobs — their prompts are meta-instructions, not queries).
+
+### Inspecting memory
+
+The HTTP API exposes (Bearer-token auth):
+- `GET /memory?source=&category=&limit=` — list recent memories
+- `GET /memory/search?q=...&topK=&source=&category=` — semantic search
+- `GET /memory/stats` — totals + breakdown by source/category
+- `GET /memory/:id` — single memory
+- `POST /memory` — manual write (debugging/seeding)
+- `DELETE /memory/:id` — forget
+
+### Required env vars
+
+- `OPENAI_API_KEY` (required) — for embeddings + mem0's extraction LLM
+- `QDRANT_URL` (default `http://localhost:6333`; on Fly set to `http://jpos-qdrant.internal:6333`)
+- `MEM0_LLM_MODEL` (default `gpt-4.1-nano`)
+- `MEM0_EMBEDDING_MODEL` (default `text-embedding-3-small`)
+- `MEM0_HISTORY_DB_PATH` (default `./mem0-history.db`; on Fly set to `/data/mem0-history.db`)
 
 ## System Prompts (in this repo)
 
@@ -85,12 +119,15 @@ The vault contains data the agent reads and writes at runtime:
 - `POST /ramble/webhook` — Ramble voice transcript webhook (auth via `X-Webhook-Secret` header, secret set as `RAMBLE_WEBHOOK_SECRET` on Fly.io)
 - `POST /agent` — General agent interaction with optional session persistence (Bearer token auth)
 - `GET /health` — Health check (no auth)
+- `GET /memory`, `/memory/search`, `/memory/stats`, `/memory/:id` — Memory inspection (Bearer token auth)
+- `POST /memory`, `DELETE /memory/:id` — Manual memory write/delete (Bearer token auth)
 
 ## Deployment
 
 - Hosted on Fly.io at `https://jpos-agent.fly.dev`
 - Auto-deploys via GitHub Actions on push to main
 - Persistent volume at `/data` for Obsidian vault
+- **Sister app:** `jpos-qdrant` (in `jpos-qdrant/` directory) — internal-only Qdrant vector store, reachable at `http://jpos-qdrant.internal:6333`. Deploy independently with `cd jpos-qdrant && fly deploy`.
 
 ## Obsidian Vault
 

--- a/.claude/skills/memory-prune/SKILL.md
+++ b/.claude/skills/memory-prune/SKILL.md
@@ -1,46 +1,49 @@
 ---
 name: memory-prune
-description: Review memory.md for stale, outdated, or redundant entries and prune them. Run periodically or on demand to keep durable memory clean and current.
+description: Review mem0 long-term memory for stale, outdated, or redundant entries and prune them. Run periodically or on demand to keep memory clean and current.
 ---
 
 # Memory Prune
 
-Review `memory.md` and remove or update entries that are stale, outdated, redundant, or no longer useful. Memory grows but rarely shrinks — this skill is the counterweight.
+Review long-term memory in mem0 and remove or update entries that are stale, outdated, redundant, contradicted, or no longer useful. mem0's automatic dedup catches the obvious overlaps on write, but it doesn't catch things that have gone stale over time — that's what this skill is for.
 
 ## Steps
 
-1. **Read the full `memory.md`** from `{{vault_path}}/jpOS/memory.md`.
+1. **Sweep recent memories.** Call `list_memories(limit=200)` to get a broad view. Optionally narrow with `source=` or `category=` if you want to focus a pass (e.g. just preferences, or just project-related entries).
 
-2. **Read recent context** — skim the last few weekly digests and daily logs to understand what's current. This helps you judge what's stale vs. what's still active.
+2. **Cross-check with recent reality.** Skim the last 1-2 weeks of `jpOS/daily-log/` to ground yourself in what's actually been happening. Old memories about "current" projects, people, or routines may have quietly become stale.
 
-3. **Evaluate each section and entry.** Flag anything that is:
-   - **Stale**: References projects, people, or contexts that are no longer active
-   - **Outdated**: Facts that have changed (e.g., old project status, shifted goals, outdated preferences)
-   - **Redundant**: Duplicated information, or things now captured better elsewhere
-   - **Too granular**: Details that were useful short-term but don't need to live in durable memory (these belong in weekly digests or daily logs, not memory.md)
+3. **Evaluate each entry.** Flag anything that is:
+   - **Stale**: references projects, people, or contexts that are no longer active (haven't appeared in logs or other memories for ~2+ months)
+   - **Outdated**: facts that have changed (old project status, shifted goals, abandoned preferences)
+   - **Contradicted**: directly conflicts with a newer memory and the newer one is correct
+   - **Redundant**: duplicated by another memory that says the same thing more clearly
+   - **Too granular**: hyper-specific details from a one-time event that don't need to persist (mem0's extractor occasionally over-stores)
 
-4. **Edit memory.md** — remove stale entries, update outdated ones, consolidate redundant sections. Preserve the structure and formatting conventions.
+4. **Act on each flag:**
+   - **Update** an outdated fact: `update_memory(memory_id, new_content)` — preferred over delete+rewrite for facts that just changed.
+   - **Delete** stale, contradicted, or redundant entries: `forget(memory_id)`.
+   - **Leave alone** anything you're not certain about — when running in the background, default to keeping.
 
-5. **Report what you did** (see Autonomy section below).
+5. **Report what you did** (see Autonomy section).
 
 ## Autonomy
 
-This skill operates differently depending on context:
-
 **Mid-conversation (Justin is present):**
-- Ask clarifying questions for entries you're genuinely unsure about — "Is [project] still active?" or "You mentioned [X] a while back, still relevant?"
-- You can be more aggressive with pruning when you can verify in real time
-- Message Justin with a brief summary of what you pruned and why
+- Ask clarifying questions for entries you're genuinely unsure about: "Is [project] still active?" or "You mentioned [X] a while back, still relevant?"
+- Be more aggressive — you can verify with him in real time.
+- Message Justin with a brief summary at the end: "Pruned 12 memories. 8 stale project entries from [project], 3 outdated preferences, 1 contradiction. Updated 4 others."
 
 **Background / cron (no active conversation):**
 - Do NOT message Justin. Silent processing.
-- Be **conservative** — when in doubt, keep it. A slightly bloated memory is better than accidentally deleting something that matters.
-- Only prune things you're confident are stale: finished projects still listed as active, people/contexts that haven't appeared in logs for months, clearly outdated facts
-- Leave a brief note in the daily log about what was pruned, so there's a record
+- Be **conservative** — when in doubt, keep it. A slightly bloated mem0 is better than accidentally deleting something that matters.
+- Only prune things you're confident are stale: finished projects still appearing as active, people/contexts that haven't shown up in logs for months, clearly outdated preferences.
+- Append a one-line note to today's daily log so there's a record of what was pruned.
 
 ## What NOT to prune
 
-- Identity-level information (personality, core preferences, long-term goals) — even if it hasn't been referenced recently
-- Relationship context (people, how Justin relates to them) — unless you're confident the relationship is no longer relevant
-- Project routing information — even for paused projects, the routing table should stay until the project is explicitly archived
-- Anything you're not sure about — when running in background, always err on the side of keeping
+- **Identity-level facts** (personality, core preferences, long-term goals) — even if not recently referenced.
+- **Relationship context** (who people are, how Justin relates to them) — unless you're confident the relationship is no longer relevant.
+- **Project routing info** (which vault note, which repo, which Linear workspace) — even for paused projects, keep it until the project is explicitly archived.
+- **Anything pre-2026-05** that came from the initial migration of `memory.md` — these were promoted to mem0 with intent; don't second-guess them in early passes.
+- **Anything you're unsure about** — when running in background, always err on the side of keeping.

--- a/.claude/skills/project-status/SKILL.md
+++ b/.claude/skills/project-status/SKILL.md
@@ -10,30 +10,34 @@ Pull the current state of a project from all available sources and synthesize a 
 
 ## Steps
 
-1. **Identify the project.** Use `$ARGUMENTS` if provided, or infer from conversation context. Check `memory.md` for the project routing table — it maps project names to vault notes and external sources.
+1. **Identify the project.** Use `$ARGUMENTS` if provided, or infer from conversation context.
 
-2. **Gather from all available sources** (check each, skip what doesn't exist):
+2. **Pull what mem0 knows about the project first.** Routing info (vault note path, repo, Linear workspace) and recent state live here:
+   - `recall(query="<project name> routing canonical note repo workspace", category="project", top_k=10)` — gets routing + structural info
+   - `recall(query="<project name> current status recent activity decisions", top_k=15)` — gets recent state, decisions, blockers
+   - If mem0 returns nothing useful, the project hasn't been captured yet — ask Justin and then `remember` what he tells you so the next call is easier.
+
+3. **Gather from external sources** (use the routing info from step 2; check each, skip what doesn't exist):
 
    **Obsidian vault:**
-   - Read the project's canonical note (from the routing table in memory.md)
+   - Read the project's canonical note (path from mem0)
    - Check the "Current Thinking" and "Log" sections for recent state
 
    **GitHub:**
-   - If a repo exists, use `gh` CLI to check:
+   - If a repo exists, use `gh` CLI:
      - `gh repo view <owner/repo>` — description, recent activity
-     - Read the repo's `CLAUDE.md` or `README.md` for project overview (use `gh api` or clone if needed)
-     - `gh issue list` — open issues, recent activity
+     - Read the repo's `CLAUDE.md` or `README.md` for project overview
+     - `gh issue list` — open issues
      - `gh pr list` — open PRs
-   - Don't go overboard — a quick pulse, not a full audit
+   - A quick pulse, not a full audit
 
    **Linear:**
    - If the project has a Linear workspace/project, check recent issues and status
 
-   **Memory & daily logs:**
-   - Search recent daily logs and weekly digests for mentions of the project
-   - Check memory.md for any stored project context
+   **Daily logs:**
+   - Skim last 1-2 weeks of `jpOS/daily-log/` for narrative mentions
 
-3. **Synthesize a status snapshot.** Keep it concise and useful:
+4. **Synthesize a status snapshot.** Keep it concise and useful:
    - What's the current state? (active, paused, shipping, blocked, etc.)
    - What's been happening recently?
    - What are the open threads or next steps?
@@ -48,5 +52,5 @@ If something is unclear or you're curious about context you can't find, ask. Jus
 ## Notes
 
 - Not every project has every source. A hobby shader project won't have Linear issues. A work project might not have a vault note yet. Work with what's available.
-- If you can't find the project at all, say so and ask Justin for pointers. This is also a good signal that the project routing table in memory.md needs updating.
-- When you discover new project info (a repo URL, a status change, a new link), update memory.md with it. Don't wait for permission.
+- If you can't find the project at all, say so and ask Justin for pointers — this signals that the routing info isn't in mem0 yet.
+- When you discover new project info (a repo URL, a status change, a new link), call `remember(content=..., source=..., category="project")`. Don't wait for permission — mem0 dedupes so over-writing is cheap.

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,23 @@ GROQ_API_KEY=your-groq-api-key
 # Ramble Webhook Secret (optional - copy from Ramble app Settings screen)
 RAMBLE_WEBHOOK_SECRET=your-ramble-webhook-secret
 
+# OpenAI API Key (required — used by mem0 for embeddings and the extraction LLM)
+OPENAI_API_KEY=your-openai-api-key
+
+# Qdrant vector store URL (defaults to http://localhost:6333 for local dev;
+# in production set to http://jpos-qdrant.internal:6333)
+QDRANT_URL=http://localhost:6333
+
+# mem0 LLM model (defaults to gpt-4.1-nano — cheap fact extraction/dedup)
+MEM0_LLM_MODEL=gpt-4.1-nano
+
+# mem0 embedding model (defaults to text-embedding-3-small)
+MEM0_EMBEDDING_MODEL=text-embedding-3-small
+
+# mem0 history SQLite path (tracks add/update/delete events on memories)
+# Default: ./mem0-history.db (local), use /data/mem0-history.db on Fly.io
+MEM0_HISTORY_DB_PATH=./mem0-history.db
+
 # Server Port
 PORT=3000
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV PATH="/root/.claude/bin:${PATH}"
 WORKDIR /app
 
 # Copy package files and install dependencies
-COPY package*.json ./
+# .npmrc enables legacy-peer-deps for mem0's stale groq-sdk pin
+COPY package*.json .npmrc ./
 RUN npm install
 
 # Copy source and build

--- a/jpos-qdrant/README.md
+++ b/jpos-qdrant/README.md
@@ -1,0 +1,44 @@
+# jpos-qdrant
+
+Vector store for jpOS's memory layer. Internal-only Fly app running the
+official `qdrant/qdrant` image. Reached by `jpos-agent` over Fly's private
+network at `http://jpos-qdrant.internal:6333`.
+
+## First-time setup
+
+```bash
+cd jpos-qdrant
+fly apps create jpos-qdrant
+fly volumes create qdrant_data --region ord --size 3 --yes
+fly deploy
+```
+
+## Update
+
+```bash
+cd jpos-qdrant && fly deploy
+```
+
+## Inspect
+
+Qdrant is internal-only, so no public dashboard. To inspect:
+
+```bash
+# Quick collection list (from inside the qdrant machine)
+fly ssh console -a jpos-qdrant -C "curl -s localhost:6333/collections"
+
+# Or from jpos-agent's perspective
+fly ssh console -a jpos-agent -C "curl -s http://jpos-qdrant.internal:6333/collections"
+```
+
+The jpos-agent HTTP API also exposes memory inspection endpoints — see
+`src/interfaces/api.ts` (`GET /memory`, `GET /memory/search`, `GET /memory/stats`).
+Those are usually the more convenient way to look around.
+
+## Reset
+
+```bash
+# WARNING: destroys all memories
+fly ssh console -a jpos-qdrant -C "rm -rf /qdrant/storage/*"
+fly machines restart -a jpos-qdrant
+```

--- a/jpos-qdrant/fly.toml
+++ b/jpos-qdrant/fly.toml
@@ -1,0 +1,49 @@
+# Fly.io configuration for jpOS Qdrant — vector store for mem0.
+#
+# Internal-only: not exposed to the public internet. Reachable from
+# jpos-agent over Fly's private network at:
+#   http://jpos-qdrant.internal:6333
+#
+# Deploy steps (first time):
+#   cd jpos-qdrant
+#   fly apps create jpos-qdrant
+#   fly volumes create qdrant_data --region ord --size 3 --yes
+#   fly deploy
+#
+# Subsequent deploys:
+#   cd jpos-qdrant && fly deploy
+app = "jpos-qdrant"
+primary_region = "ord"
+
+[build]
+  image = "qdrant/qdrant:latest"
+
+[env]
+  # Bind Qdrant on all interfaces so .internal DNS reaches it.
+  QDRANT__SERVICE__HTTP_PORT = "6333"
+  QDRANT__SERVICE__GRPC_PORT = "6334"
+  # Keep telemetry off for a personal-data store.
+  QDRANT__TELEMETRY_DISABLED = "true"
+
+[mounts]
+  source = "qdrant_data"
+  destination = "/qdrant/storage"
+
+# Internal TCP service on 6333 (HTTP). No [http_service] = no public exposure.
+# Other Fly apps in the same org reach it via jpos-qdrant.internal:6333.
+[[services]]
+  internal_port = 6333
+  protocol = "tcp"
+  auto_start_machines = true
+  auto_stop_machines = false
+  min_machines_running = 1
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "10s"
+
+[[vm]]
+  memory = "1024mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",
         "@fastify/bearer-auth": "^9.4.0",
-        "@fastify/multipart": "^8.3.1",
         "dotenv": "^16.4.1",
         "fastify": "^4.26.0",
         "grammy": "^1.41.1",
         "groq-sdk": "^0.37.0",
+        "mem0ai": "^3.0.3",
         "node-cron": "^3.0.3"
       },
       "devDependencies": {
@@ -199,26 +199,6 @@
         "fastify-plugin": "^4.0.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
-      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
-    },
-    "node_modules/@fastify/deepmerge": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-2.0.2.tgz",
-      "integrity": "sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ]
-    },
     "node_modules/@fastify/error": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
@@ -239,34 +219,6 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
-    },
-    "node_modules/@fastify/multipart": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-8.3.1.tgz",
-      "integrity": "sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==",
-      "dependencies": {
-        "@fastify/busboy": "^3.0.0",
-        "@fastify/deepmerge": "^2.0.0",
-        "@fastify/error": "^4.0.0",
-        "fastify-plugin": "^4.0.0",
-        "secure-json-parse": "^2.4.0",
-        "stream-wormhole": "^1.1.0"
-      }
-    },
-    "node_modules/@fastify/multipart/node_modules/@fastify/error": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
-      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ]
     },
     "node_modules/@grammyjs/types": {
       "version": "3.25.0",
@@ -812,6 +764,16 @@
       "dependencies": {
         "@fastify/error": "^3.3.0",
         "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1532,6 +1494,25 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -2038,6 +2019,62 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mem0ai": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mem0ai/-/mem0ai-3.0.3.tgz",
+      "integrity": "sha512-nKwGYNh8DipG9Sw0ik/huFLpKtVtwadSy+T6GjAxkkrHp6hO3tlbR75EWH/bCGDG/HO06nYDsDP5fPSnj3bp5g==",
+      "dependencies": {
+        "axios": "1.13.6",
+        "openai": "^4.93.0",
+        "uuid": "9.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.40.1",
+        "@azure/identity": "^4.0.0",
+        "@azure/search-documents": "^12.0.0",
+        "@cloudflare/workers-types": "^4.20250504.0",
+        "@google/genai": "^1.2.0",
+        "@langchain/core": "^1.0.0",
+        "@mistralai/mistralai": "^1.5.2",
+        "@qdrant/js-client-rest": "1.13.0",
+        "@supabase/supabase-js": "^2.49.1",
+        "@types/jest": "29.5.14",
+        "@types/pg": "8.11.0",
+        "better-sqlite3": "^12.6.2",
+        "cloudflare": "^4.2.0",
+        "compromise": "^14.0.0",
+        "groq-sdk": "0.3.0",
+        "natural": "^8.0.1",
+        "ollama": "^0.5.14",
+        "pg": "8.11.3",
+        "redis": "^4.6.13"
+      }
+    },
+    "node_modules/mem0ai/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/mem0ai/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2170,6 +2207,48 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2352,6 +2431,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2563,14 +2647,6 @@
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/stream-wormhole": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
-      "integrity": "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -2800,15 +2876,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fastify": "^4.26.0",
     "grammy": "^1.41.1",
     "groq-sdk": "^0.37.0",
+    "mem0ai": "^3.0.3",
     "node-cron": "^3.0.3"
   },
   "devDependencies": {

--- a/scripts/mem-smoke-test.ts
+++ b/scripts/mem-smoke-test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end smoke test for the mem0 + Qdrant memory store.
+ *
+ * Prereqs:
+ *   1. Qdrant running on localhost:6333
+ *      docker run -d --name jpos-qdrant-test -p 6333:6333 -p 6334:6334 \
+ *        -v $(pwd)/.qdrant-data:/qdrant/storage qdrant/qdrant
+ *   2. OPENAI_API_KEY set (in .env or shell env)
+ *
+ * Run:
+ *   npx tsx scripts/mem-smoke-test.ts
+ */
+
+import { config } from "dotenv";
+import {
+  remember,
+  recall,
+  listMemories,
+  forget,
+  COLLECTION_NAME,
+  JPOS_USER_ID,
+} from "../src/memory-store.js";
+
+config();
+
+function divider(title: string) {
+  console.log(`\n${"=".repeat(60)}\n${title}\n${"=".repeat(60)}`);
+}
+
+async function main() {
+  console.log(`Collection: ${COLLECTION_NAME}`);
+  console.log(`User ID:    ${JPOS_USER_ID}`);
+  console.log(`Qdrant URL: ${process.env.QDRANT_URL || "http://localhost:6333 (default)"}`);
+  console.log(`LLM model:  ${process.env.MEM0_LLM_MODEL || "gpt-4.1-nano (default)"}`);
+
+  // --- 1. Write a couple memories ----------------------------------------
+  divider("1. remember() — store a few facts");
+
+  const r1 = await remember({
+    content: "I prefer dark mode in all my apps. Bright white screens hurt my eyes.",
+    source: "smoke-test",
+    category: "preference",
+  });
+  console.log(`Wrote ${r1.length} memories from preference note:`);
+  r1.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
+
+  const r2 = await remember({
+    content:
+      "Working on jpOS — my personal AI agent on Fly.io with Telegram + HTTP interfaces. " +
+      "Currently rebuilding the memory layer around mem0 + Qdrant.",
+    source: "smoke-test",
+    category: "project",
+  });
+  console.log(`\nWrote ${r2.length} memories from project note:`);
+  r2.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
+
+  const r3 = await remember({
+    content: "I drink black coffee every morning, no sugar, no milk.",
+    source: "smoke-test",
+    category: "preference",
+  });
+  console.log(`\nWrote ${r3.length} memories from coffee note:`);
+  r3.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
+
+  // --- 2. Search ----------------------------------------------------------
+  divider("2. recall() — semantic search");
+
+  const query1 = "what are my UI preferences?";
+  console.log(`Query: "${query1}"`);
+  const search1 = await recall({ query: query1, topK: 3 });
+  search1.forEach((m) =>
+    console.log(`  (score=${m.score?.toFixed(3) ?? "?"}) [${m.id.slice(0, 8)}] ${m.memory}`),
+  );
+
+  const query2 = "what am I building right now?";
+  console.log(`\nQuery: "${query2}"`);
+  const search2 = await recall({ query: query2, topK: 3 });
+  search2.forEach((m) =>
+    console.log(`  (score=${m.score?.toFixed(3) ?? "?"}) [${m.id.slice(0, 8)}] ${m.memory}`),
+  );
+
+  // --- 3. Filter by source/category --------------------------------------
+  divider("3. recall() with category filter");
+
+  const query3 = "what do I like?";
+  console.log(`Query: "${query3}", filter: category=preference`);
+  const search3 = await recall({
+    query: query3,
+    topK: 5,
+    filters: { category: "preference" },
+  });
+  search3.forEach((m) =>
+    console.log(`  (score=${m.score?.toFixed(3) ?? "?"}) [${m.id.slice(0, 8)}] ${m.memory}`),
+  );
+
+  // --- 4. List all --------------------------------------------------------
+  divider("4. listMemories() — browse all");
+
+  const all = await listMemories({ limit: 20 });
+  console.log(`Total: ${all.length} memories`);
+  all.forEach((m) =>
+    console.log(`  [${m.id.slice(0, 8)}] (${m.metadata?.category ?? "—"}) ${m.memory}`),
+  );
+
+  // --- 5. Delete one ------------------------------------------------------
+  divider("5. forget() — delete a memory");
+
+  if (all.length > 0) {
+    const target = all[0];
+    console.log(`Deleting: [${target.id.slice(0, 8)}] ${target.memory}`);
+    await forget(target.id);
+    const afterDelete = await listMemories({ limit: 20 });
+    console.log(`After delete: ${afterDelete.length} memories remaining`);
+  }
+
+  divider("Done");
+  console.log("All operations completed successfully.\n");
+}
+
+main().catch((err) => {
+  console.error("\n[FAILED]", err);
+  process.exit(1);
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { getSession, setSession } from "./sessions.js";
 import { env } from "./config.js";
+import { recall } from "./memory-store.js";
 import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -16,18 +17,80 @@ interface RunAgentParams {
   prompt: string;
   externalId: string;
   systemContext?: string;
+  /**
+   * Whether to auto-recall relevant memories from mem0 based on `prompt`
+   * and inject them into the system prompt. Defaults to true.
+   * Set false for cron jobs where the prompt is an instruction, not a query.
+   */
+  autoRecall?: boolean;
+  /** Max memories to surface in auto-recall. Defaults to 5. */
+  autoRecallTopK?: number;
   /** Called with accumulated text as streaming deltas arrive */
   onTextDelta?: (accumulatedText: string) => void;
   /** Called immediately when the agent sends a message via the message_user tool */
   onMessage?: (text: string) => void;
 }
 
+/**
+ * Search mem0 for memories relevant to `prompt` and format them as a
+ * system-prompt section. Returns empty string if mem0 is unreachable or returns
+ * no hits — the agent should still respond, just without recalled context.
+ */
+async function autoRecallSection(prompt: string, topK: number): Promise<string> {
+  try {
+    const memories = await recall({ query: prompt, topK });
+    if (memories.length === 0) return "";
+
+    const lines = memories.map((m) => {
+      const meta = m.metadata as Record<string, unknown> | undefined;
+      const source = meta?.source ? ` (${meta.source})` : "";
+      const score = m.score != null ? ` [score=${m.score.toFixed(2)}]` : "";
+      return `- ${m.memory}${source}${score}`;
+    });
+
+    return [
+      "# Recalled Memories",
+      "",
+      `*The following ${memories.length} memories surfaced as most relevant to the user's message. Use them as context but verify if anything seems stale.*`,
+      "",
+      ...lines,
+      "",
+    ].join("\n");
+  } catch (err) {
+    console.error(
+      "[agent] auto-recall failed (continuing without recalled context):",
+      err instanceof Error ? err.message : err,
+    );
+    return "";
+  }
+}
+
 export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
-  const { prompt, externalId, systemContext, onTextDelta, onMessage } = params;
+  const {
+    prompt,
+    externalId,
+    systemContext,
+    autoRecall = true,
+    autoRecallTopK = 5,
+    onTextDelta,
+    onMessage,
+  } = params;
 
   const existingSession = getSession(externalId);
   let sessionId: string | undefined = existingSession?.agentSessionId;
   let result = "";
+
+  // Auto-recall: surface relevant memories from mem0 and append to systemContext.
+  // Fail-graceful — if mem0/Qdrant is down, agent still runs without recalled context.
+  let finalSystemContext = systemContext;
+  if (autoRecall && prompt && prompt.trim().length > 0) {
+    const recallSection = await autoRecallSection(prompt, autoRecallTopK);
+    if (recallSection) {
+      finalSystemContext = finalSystemContext
+        ? `${finalSystemContext}\n\n${recallSection}`
+        : recallSection;
+    }
+  }
 
   // Temp file for collecting message_user calls (only needed when no onMessage callback)
   const messageFile = onMessage
@@ -51,6 +114,17 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
         TODOIST_API_TOKEN: env.todoistApiToken,
       },
     },
+    memory: {
+      command: "node",
+      args: [process.env.MCP_MEMORY_PATH || "/app/dist/mcp/memory.js"],
+      env: {
+        OPENAI_API_KEY: env.openaiApiKey,
+        QDRANT_URL: env.qdrantUrl,
+        MEM0_LLM_MODEL: env.mem0LlmModel,
+        MEM0_EMBEDDING_MODEL: env.mem0EmbeddingModel,
+        MEM0_HISTORY_DB_PATH: env.mem0HistoryDbPath,
+      },
+    },
   };
 
   // Build allowed tools list
@@ -61,6 +135,11 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
     "mcp__todoist__todoist_list_tasks",
     "mcp__todoist__todoist_complete_task",
     "mcp__todoist__todoist_list_projects",
+    "mcp__memory__remember",
+    "mcp__memory__recall",
+    "mcp__memory__list_memories",
+    "mcp__memory__forget",
+    "mcp__memory__update_memory",
   ];
 
   // Conditionally add App Store Connect MCP server
@@ -123,8 +202,8 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
       includePartialMessages: !!onTextDelta,
       // System prompt is ephemeral (not stored in conversation history),
       // so it must be passed on every call including resumes.
-      ...(systemContext
-        ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext } }
+      ...(finalSystemContext
+        ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: finalSystemContext } }
         : {}),
       ...(sessionId ? { resume: sessionId } : {}),
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,12 @@ export const env = {
   groqApiKey: requireEnv("GROQ_API_KEY"),
   rambleWebhookSecret: process.env.RAMBLE_WEBHOOK_SECRET || "",
   port: parseInt(process.env.PORT || "3000", 10),
+  // mem0 memory layer (Qdrant vector store + OpenAI for LLM + embeddings)
+  openaiApiKey: requireEnv("OPENAI_API_KEY"),
+  qdrantUrl: process.env.QDRANT_URL || "http://localhost:6333",
+  mem0LlmModel: process.env.MEM0_LLM_MODEL || "gpt-4.1-nano",
+  mem0EmbeddingModel: process.env.MEM0_EMBEDDING_MODEL || "text-embedding-3-small",
+  mem0HistoryDbPath: process.env.MEM0_HISTORY_DB_PATH || "./mem0-history.db",
   // App Store Connect (optional - tools disabled if not set)
   appStoreConnectKeyId: process.env.APP_STORE_CONNECT_KEY_ID || "",
   appStoreConnectIssuerId: process.env.APP_STORE_CONNECT_ISSUER_ID || "",

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -47,6 +47,7 @@ async function runDailyPrep(): Promise<void> {
         prompt: "Generate the daily prep briefing as described in your instructions.",
         externalId: "cron:daily-prep",
         systemContext,
+        autoRecall: false,
       }),
       timeoutPromise,
     ]);
@@ -92,6 +93,7 @@ async function runEodCheckin(): Promise<void> {
         prompt: "Send the end-of-day check-in as described in your instructions.",
         externalId: "cron:eod-checkin",
         systemContext,
+        autoRecall: false,
       }),
       timeoutPromise,
     ]);
@@ -146,6 +148,7 @@ async function runWeeklyReview(): Promise<void> {
         prompt: "Run the weekly-review skill: synthesize the past 7 daily logs into a weekly digest and promote anything durable to memory.md.",
         externalId: "cron:weekly-review",
         systemContext,
+        autoRecall: false,
       }),
       timeoutPromise,
     ]);
@@ -184,6 +187,7 @@ async function runMonthlyReview(): Promise<void> {
         prompt: "Run the month-in-review skill: compress the past month's weekly digests into a monthly summary and promote anything durable to memory.md.",
         externalId: "cron:monthly-review",
         systemContext,
+        autoRecall: false,
       }),
       timeoutPromise,
     ]);

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -5,6 +5,13 @@ import { env } from "../config.js";
 import { runAgent } from "../agent.js";
 import { requestSync } from "../vault-sync.js";
 import { processWebhook } from "../ramble.js";
+import {
+  listMemories,
+  recall,
+  forget,
+  remember,
+  getMemoryById,
+} from "../memory-store.js";
 
 function verifyWebhookSignature(rawBody: Buffer, signature: string, secret: string): boolean {
   const expected =
@@ -81,7 +88,126 @@ export async function createApiServer() {
       keys: new Set([env.apiBearerToken]),
     });
 
-    // Main agent endpoint
+    // ---- Memory inspection / management ---------------------------------
+    // List recent memories. Optional filters: ?source=&category=&limit=
+    app.get<{
+      Querystring: { source?: string; category?: string; limit?: string };
+    }>("/memory", async (request, reply) => {
+      try {
+        const { source, category, limit } = request.query;
+        const filters: Record<string, unknown> = {};
+        if (source) filters.source = source;
+        if (category) filters.category = category;
+        const memories = await listMemories({
+          limit: limit ? parseInt(limit, 10) : 50,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
+        });
+        return { count: memories.length, memories };
+      } catch (error) {
+        return reply.status(500).send({
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    });
+
+    // Semantic search. ?q=...&topK=...&source=&category=
+    app.get<{
+      Querystring: { q?: string; topK?: string; source?: string; category?: string };
+    }>("/memory/search", async (request, reply) => {
+      const { q, topK, source, category } = request.query;
+      if (!q) {
+        return reply.status(400).send({ error: "query param 'q' is required" });
+      }
+      try {
+        const filters: Record<string, unknown> = {};
+        if (source) filters.source = source;
+        if (category) filters.category = category;
+        const memories = await recall({
+          query: q,
+          topK: topK ? parseInt(topK, 10) : 10,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
+        });
+        return { count: memories.length, memories };
+      } catch (error) {
+        return reply.status(500).send({
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    });
+
+    // Aggregate stats: count by source and category
+    app.get("/memory/stats", async (_request, reply) => {
+      try {
+        const all = await listMemories({ limit: 10000 });
+        const bySource: Record<string, number> = {};
+        const byCategory: Record<string, number> = {};
+        for (const m of all) {
+          const meta = m.metadata as Record<string, unknown> | undefined;
+          const src = (meta?.source as string) || "(none)";
+          const cat = (meta?.category as string) || "(none)";
+          bySource[src] = (bySource[src] ?? 0) + 1;
+          byCategory[cat] = (byCategory[cat] ?? 0) + 1;
+        }
+        return {
+          total: all.length,
+          bySource,
+          byCategory,
+        };
+      } catch (error) {
+        return reply.status(500).send({
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    });
+
+    // Get a single memory by id
+    app.get<{ Params: { id: string } }>(
+      "/memory/:id",
+      async (request, reply) => {
+        try {
+          const memory = await getMemoryById(request.params.id);
+          if (!memory) return reply.status(404).send({ error: "Not found" });
+          return memory;
+        } catch (error) {
+          return reply.status(500).send({
+            error: error instanceof Error ? error.message : "Unknown error",
+          });
+        }
+      },
+    );
+
+    // Manual write (mostly for debugging / seeding)
+    app.post<{
+      Body: { content: string; source?: string; category?: string; infer?: boolean };
+    }>("/memory", async (request, reply) => {
+      const { content, source, category, infer } = request.body;
+      if (!content) return reply.status(400).send({ error: "content required" });
+      try {
+        const memories = await remember({ content, source, category, infer });
+        return { added: memories.length, memories };
+      } catch (error) {
+        return reply.status(500).send({
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    });
+
+    // Delete a memory by id
+    app.delete<{ Params: { id: string } }>(
+      "/memory/:id",
+      async (request, reply) => {
+        try {
+          await forget(request.params.id);
+          return { success: true, id: request.params.id };
+        } catch (error) {
+          return reply.status(500).send({
+            error: error instanceof Error ? error.message : "Unknown error",
+          });
+        }
+      },
+    );
+
+    // ---- Main agent endpoint --------------------------------------------
     app.post<{
       Body: {
         prompt: string;

--- a/src/mcp/memory.ts
+++ b/src/mcp/memory.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Memory MCP Server
+ *
+ * Exposes the mem0-backed memory store to the agent as tool calls:
+ *   - remember:      store something to long-term memory
+ *   - recall:        semantic search over past memories
+ *   - list_memories: list recent / filtered memories
+ *   - forget:        delete a memory by id
+ *   - update_memory: rewrite a memory's content
+ *
+ * Env: OPENAI_API_KEY (required), QDRANT_URL, MEM0_LLM_MODEL,
+ * MEM0_EMBEDDING_MODEL, MEM0_HISTORY_DB_PATH.
+ */
+
+import {
+  remember,
+  recall,
+  listMemories,
+  forget,
+  updateMemory,
+} from "../memory-store.js";
+
+const tools = [
+  {
+    name: "remember",
+    description:
+      "Store something to long-term memory. Use when the user shares a preference, " +
+      "fact about themselves, a decision, a commitment, or anything you should know " +
+      "in future conversations. mem0 will extract atomic facts from the content unless " +
+      "infer=false (in which case the content is stored verbatim as a single memory).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        content: {
+          type: "string",
+          description: "The raw text or observation to remember.",
+        },
+        source: {
+          type: "string",
+          description:
+            "Where this memory came from (e.g., 'voice-note', 'telegram', 'daily-prep'). " +
+            "Used for filtering during recall.",
+        },
+        category: {
+          type: "string",
+          description:
+            "Optional category tag (e.g., 'preference', 'project', 'person'). " +
+            "Used for filtering during recall.",
+        },
+        infer: {
+          type: "boolean",
+          description:
+            "If true (default), mem0's LLM extracts atomic facts from content and " +
+            "decides whether to add/update/delete existing memories. " +
+            "If false, content is stored verbatim as a single memory.",
+        },
+      },
+      required: ["content"],
+    },
+  },
+  {
+    name: "recall",
+    description:
+      "Semantic search over long-term memory. Use proactively when the user " +
+      "references something past, asks about themselves, or when you need context " +
+      "to answer well. Returns memories ranked by relevance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Natural-language query to search memories for.",
+        },
+        top_k: {
+          type: "number",
+          description: "Max number of memories to return (default 5).",
+        },
+        source: {
+          type: "string",
+          description: "Optional filter: only return memories from this source.",
+        },
+        category: {
+          type: "string",
+          description: "Optional filter: only return memories with this category.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "list_memories",
+    description:
+      "List recent memories without a semantic query. Useful for browsing or " +
+      "filtering by source/category.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Max memories to return (default 50)." },
+        source: { type: "string", description: "Filter by source." },
+        category: { type: "string", description: "Filter by category." },
+      },
+    },
+  },
+  {
+    name: "forget",
+    description:
+      "Delete a memory by its ID. Use when the user asks to forget something or " +
+      "when a memory is clearly wrong or outdated. The ID comes from recall/list_memories.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        memory_id: { type: "string", description: "ID of the memory to delete." },
+      },
+      required: ["memory_id"],
+    },
+  },
+  {
+    name: "update_memory",
+    description:
+      "Rewrite the content of an existing memory by ID. Use when a fact changes " +
+      "and you want to overwrite rather than add a contradicting memory.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        memory_id: { type: "string", description: "ID of the memory to update." },
+        content: { type: "string", description: "New content for the memory." },
+      },
+      required: ["memory_id", "content"],
+    },
+  },
+];
+
+interface ToolArgs {
+  content?: string;
+  source?: string;
+  category?: string;
+  infer?: boolean;
+  query?: string;
+  top_k?: number;
+  limit?: number;
+  memory_id?: string;
+}
+
+async function handleToolCall(name: string, args: ToolArgs): Promise<unknown> {
+  switch (name) {
+    case "remember": {
+      if (!args.content) throw new Error("remember requires 'content'");
+      const items = await remember({
+        content: args.content,
+        source: args.source,
+        category: args.category,
+        infer: args.infer,
+      });
+      return { added: items.length, memories: items };
+    }
+
+    case "recall": {
+      if (!args.query) throw new Error("recall requires 'query'");
+      const filters: Record<string, unknown> = {};
+      if (args.source) filters.source = args.source;
+      if (args.category) filters.category = args.category;
+      const items = await recall({
+        query: args.query,
+        topK: args.top_k,
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+      });
+      return { count: items.length, memories: items };
+    }
+
+    case "list_memories": {
+      const filters: Record<string, unknown> = {};
+      if (args.source) filters.source = args.source;
+      if (args.category) filters.category = args.category;
+      const items = await listMemories({
+        limit: args.limit,
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+      });
+      return { count: items.length, memories: items };
+    }
+
+    case "forget": {
+      if (!args.memory_id) throw new Error("forget requires 'memory_id'");
+      await forget(args.memory_id);
+      return { success: true, memory_id: args.memory_id };
+    }
+
+    case "update_memory": {
+      if (!args.memory_id || !args.content) {
+        throw new Error("update_memory requires 'memory_id' and 'content'");
+      }
+      await updateMemory(args.memory_id, args.content);
+      return { success: true, memory_id: args.memory_id };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+async function main() {
+  const readline = await import("readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+
+  for await (const line of rl) {
+    let requestId: unknown = null;
+    try {
+      const request = JSON.parse(line);
+      requestId = request.id;
+      let response: unknown;
+
+      switch (request.method) {
+        case "initialize":
+          response = {
+            protocolVersion: "2024-11-05",
+            capabilities: { tools: {} },
+            serverInfo: { name: "memory-mcp", version: "1.0.0" },
+          };
+          break;
+
+        case "tools/list":
+          response = { tools };
+          break;
+
+        case "tools/call": {
+          const result = await handleToolCall(
+            request.params.name,
+            request.params.arguments || {},
+          );
+          response = {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          };
+          break;
+        }
+
+        default:
+          response = { error: { code: -32601, message: "Method not found" } };
+      }
+
+      console.log(JSON.stringify({ jsonrpc: "2.0", id: request.id, result: response }));
+    } catch (error) {
+      console.log(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: requestId,
+          error: {
+            code: -32603,
+            message: error instanceof Error ? error.message : "Unknown error",
+          },
+        }),
+      );
+    }
+  }
+}
+
+main().catch(console.error);

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -1,0 +1,216 @@
+/**
+ * Memory store — thin wrapper around mem0 (https://github.com/mem0ai/mem0)
+ * configured with Qdrant for vectors, OpenAI for embeddings, and an OpenAI
+ * mini-tier LLM for extraction/dedup.
+ *
+ * Single-user system: all memories are written under a fixed userId ("jp").
+ * Use metadata.source ("voice-note", "telegram", "daily-prep", "manual", etc.)
+ * to distinguish where a memory came from.
+ */
+
+import { Memory, type MemoryItem } from "mem0ai/oss";
+
+/**
+ * Read env vars directly (not via ./config.js) so this module is safe to import
+ * from MCP subprocesses, which don't have the full jpOS env (no Telegram token, etc.).
+ * The parent process passes OPENAI_API_KEY + QDRANT_URL via MCP server config.
+ */
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export const JPOS_USER_ID = "jp";
+export const COLLECTION_NAME = "jpos_memories";
+
+let memoryInstance: Memory | null = null;
+
+function parseQdrantUrl(url: string): { host: string; port: number } {
+  const parsed = new URL(url);
+  return {
+    host: parsed.hostname,
+    port: parsed.port ? parseInt(parsed.port, 10) : 6333,
+  };
+}
+
+function getMemory(): Memory {
+  if (memoryInstance) return memoryInstance;
+
+  const openaiApiKey = requireEnv("OPENAI_API_KEY");
+  const qdrantUrl = process.env.QDRANT_URL || "http://localhost:6333";
+  const llmModel = process.env.MEM0_LLM_MODEL || "gpt-4.1-nano";
+  const embeddingModel = process.env.MEM0_EMBEDDING_MODEL || "text-embedding-3-small";
+  const historyDbPath = process.env.MEM0_HISTORY_DB_PATH || "./mem0-history.db";
+
+  const { host, port } = parseQdrantUrl(qdrantUrl);
+  console.log(
+    `[mem0] init           | qdrant=${host}:${port} collection=${COLLECTION_NAME} ` +
+      `llm=${llmModel} embed=${embeddingModel} historyDb=${historyDbPath}`,
+  );
+
+  memoryInstance = new Memory({
+    embedder: {
+      provider: "openai",
+      config: { apiKey: openaiApiKey, model: embeddingModel },
+    },
+    vectorStore: {
+      provider: "qdrant",
+      config: { host, port, collectionName: COLLECTION_NAME },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: openaiApiKey, model: llmModel },
+    },
+    historyDbPath,
+  });
+
+  return memoryInstance;
+}
+
+export interface RememberParams {
+  /** Raw text to remember. */
+  content: string;
+  /** Where this memory came from (voice-note, telegram, daily-prep, etc.). */
+  source?: string;
+  /** Optional category tag for filtering later. */
+  category?: string;
+  /** Free-form metadata merged with source/category. */
+  metadata?: Record<string, unknown>;
+  /**
+   * Whether to use mem0's LLM-driven fact extraction (default true).
+   * Set false to store `content` verbatim as a single memory.
+   */
+  infer?: boolean;
+}
+
+export async function remember(params: RememberParams): Promise<MemoryItem[]> {
+  const { content, source, category, metadata, infer = true } = params;
+  const memory = getMemory();
+
+  const fullMetadata: Record<string, unknown> = {
+    ...(metadata ?? {}),
+    timestamp: new Date().toISOString(),
+  };
+  if (source) fullMetadata.source = source;
+  if (category) fullMetadata.category = category;
+
+  const start = Date.now();
+  const preview = content.slice(0, 80).replace(/\s+/g, " ");
+  console.log(
+    `[mem0] remember start | source=${source ?? "-"} category=${category ?? "-"} infer=${infer} content="${preview}${content.length > 80 ? "…" : ""}"`,
+  );
+
+  try {
+    const result = await memory.add(content, {
+      userId: JPOS_USER_ID,
+      metadata: fullMetadata,
+      infer,
+    });
+    console.log(
+      `[mem0] remember done  | ${result.results.length} memories in ${Date.now() - start}ms`,
+    );
+    return result.results;
+  } catch (err) {
+    console.error(
+      `[mem0] remember FAIL  | ${Date.now() - start}ms |`,
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
+}
+
+export interface RecallParams {
+  query: string;
+  topK?: number;
+  /** Optional metadata filters (e.g., { source: "voice-note" }). */
+  filters?: Record<string, unknown>;
+  /** Minimum similarity score (0-1). */
+  threshold?: number;
+}
+
+export async function recall(params: RecallParams): Promise<MemoryItem[]> {
+  const { query, topK = 5, filters, threshold } = params;
+  const memory = getMemory();
+  const start = Date.now();
+  const preview = query.slice(0, 80).replace(/\s+/g, " ");
+  console.log(
+    `[mem0] recall start   | topK=${topK} filters=${filters ? JSON.stringify(filters) : "-"} query="${preview}${query.length > 80 ? "…" : ""}"`,
+  );
+
+  try {
+    const result = await memory.search(query, {
+      topK,
+      filters: { user_id: JPOS_USER_ID, ...(filters ?? {}) },
+      threshold,
+    });
+    const scores = result.results.map((r) => r.score?.toFixed(2)).join(",");
+    console.log(
+      `[mem0] recall done    | ${result.results.length} hits in ${Date.now() - start}ms | scores=[${scores}]`,
+    );
+    return result.results;
+  } catch (err) {
+    console.error(
+      `[mem0] recall FAIL    | ${Date.now() - start}ms |`,
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
+}
+
+export interface ListMemoriesParams {
+  limit?: number;
+  filters?: Record<string, unknown>;
+}
+
+export async function listMemories(
+  params: ListMemoriesParams = {},
+): Promise<MemoryItem[]> {
+  const { limit = 50, filters } = params;
+  const memory = getMemory();
+  const start = Date.now();
+  console.log(
+    `[mem0] list start     | limit=${limit} filters=${filters ? JSON.stringify(filters) : "-"}`,
+  );
+
+  try {
+    const result = await memory.getAll({
+      topK: limit,
+      filters: { user_id: JPOS_USER_ID, ...(filters ?? {}) },
+    });
+    console.log(
+      `[mem0] list done      | ${result.results.length} memories in ${Date.now() - start}ms`,
+    );
+    return result.results;
+  } catch (err) {
+    console.error(
+      `[mem0] list FAIL      | ${Date.now() - start}ms |`,
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
+}
+
+export async function forget(memoryId: string): Promise<void> {
+  const memory = getMemory();
+  console.log(`[mem0] forget         | id=${memoryId}`);
+  await memory.delete(memoryId);
+}
+
+export async function updateMemory(
+  memoryId: string,
+  newContent: string,
+): Promise<void> {
+  const memory = getMemory();
+  console.log(`[mem0] update         | id=${memoryId}`);
+  await memory.update(memoryId, newContent);
+}
+
+export async function getMemoryById(
+  memoryId: string,
+): Promise<MemoryItem | null> {
+  const memory = getMemory();
+  return memory.get(memoryId);
+}

--- a/system/instructions.md
+++ b/system/instructions.md
@@ -2,51 +2,69 @@
 
 ## Memory System
 
-jpOS has two layers of memory:
+jpOS uses **mem0** (vector store on Qdrant) as long-term semantic memory. Memories are atomic facts — preferences, decisions, people, projects, patterns — automatically extracted from whatever content you pass to `remember`, deduped against existing memories, and surfaced on demand.
 
-### Durable Memory (`jpOS/memory.md`)
+### Recall — how you get context
 
-Long-term knowledge about Justin and his world — people, projects, goals, preferences, and anything else worth remembering. Read this file at the start of every interaction for context.
+**Relevant memories are auto-injected** under a `# Recalled Memories` section in your context on every direct user message. You don't need to call `recall` to get baseline context — it's already there.
 
-**Update it whenever you learn something durable.** Don't wait for permission. If it'll matter again later, write it down. Add new sections as needed — the structure is a starting point, not a constraint.
+**Call `recall(query, top_k?, source?, category?)` explicitly when:**
+- The auto-recalled memories didn't surface what you need for the current task
+- You're answering something specific where the user's message was vague (e.g. user says "any thoughts on this?" — auto-recall on that won't find much; recall with the actual topic will)
+- You're starting a longer task and want to load wider context up front
+- You want to filter by source (e.g. `source="voice-note"` to see only what came from voice notes) or category
 
-### Monthly Summaries (`jpOS/monthly-digest/YYYY-MM.md`)
+**Cron-triggered tasks (daily-prep, eod-checkin, weekly-review, monthly-review) DO NOT get auto-recall** — their prompts are meta-instructions, not queries. If you're running one of those skills and need memory context, you must call `recall` yourself.
 
-Compressed summaries of each month — broader arcs, trends, and shifts that only emerge over weeks. Generated automatically on the 1st of each month from that month's weekly digests. The last 3 months are loaded into context automatically.
+### Writing memories — call `remember` liberally
 
-### Weekly Digests (`jpOS/weekly-digest/YYYY-WXX.md`)
+**After any substantive user input, call `remember(content, source, category?)` for anything worth carrying forward.** Don't wait for "remember this" — write it if:
 
-Synthesized summaries of each week — patterns, key decisions, insights, open threads. Generated automatically every Sunday evening from that week's daily logs. The last 4 weeks are loaded into context automatically.
+- The user shared a preference, opinion, or aesthetic choice
+- A decision was made or a commitment surfaced (his, or about something/someone)
+- A new person, project, or context was introduced
+- The status of an existing person/project changed
+- A pattern was noticed (physical state, energy, recurring frustration, what compounds vitality)
+- Anything you'd want to know in a future conversation
 
-Together, these layers form a graduated compression system: daily logs (3-day window) → weekly digests (~4-week window) → monthly summaries (~3-month window) → durable memory (permanent). Each level promotes anything that clears the bar for the next level up.
+mem0's extraction LLM decides what atomic facts to actually store and dedupes against existing memories. Overwriting noise is cheap; missing a useful fact is expensive. Lean toward writing more, not less.
 
-### Daily Memory (`jpOS/daily-log/YYYY-MM-DD.md`)
+**`source` is required.** Pass one of: `"telegram"`, `"voice-note"`, `"daily-prep"`, `"eod-checkin"`, `"manual"`, or whatever describes what triggered the memory. Used for filtering later.
 
-After every interaction append a timestamped entry to today's file (America/New_York timezone).
+**`category` is optional** but helpful for browsing. Suggested values: `"preference"`, `"project"`, `"person"`, `"commitment"`, `"health"`, `"pattern"`, `"opinion"`.
 
-**Format:**
+### Forgetting & updating
+
+- **`forget(memory_id)`** — only when the user explicitly asks to forget something, or when a memory is clearly wrong/outdated/contradicted. IDs come from `recall` or `list_memories`.
+- **`update_memory(memory_id, new_content)`** — when a fact changes, prefer this over writing a contradicting memory.
+
+### Browsing
+
+- **`list_memories(source?, category?, limit?)`** — browse recent memories without a semantic query. Useful for orienting at the start of a longer task.
+
+### Daily Log (`jpOS/daily-log/YYYY-MM-DD.md`)
+
+A human-readable breadcrumb trail Justin browses in Obsidian. **Not used for your recall — mem0 handles that.** This is just a lightweight record of what happened, written for him to skim later.
+
+After meaningful exchanges, append a timestamped entry to today's file (America/New_York timezone):
+
 ```
 ### HH:MM AM/PM
-- Concise bullet points summarizing what happened
-- Actions taken, decisions made, info learned
-- Keep it brief — this is for future context, not a transcript
+- Concise bullets: what happened, actions taken, info learned
 ```
 
-**Rules:**
-- One entry per interaction, appended to the end
-- Create the file if it doesn't exist (no frontmatter needed)
-- Include: actions taken, key info learned, user's mood/state if notable, physical state if mentioned (energy level, movement, tension, body cues), gratitude or positive moments if shared
-- Skip: routine acknowledgments, small talk with no new info
-- **Log during the conversation, not just at the end.** After any exchange with meaningful content, write the entry before moving on. Don't batch up multiple turns and try to log them all later.
+Skip routine acknowledgments and small talk. One entry per interaction, appended to the end. Create the file if it doesn't exist. Log during the conversation, not just at the end.
+
+Use this for the **human-readable narrative**; use `remember` for **atomic facts**. They serve different purposes — the daily log is a journal, mem0 is searchable knowledge.
 
 ## Project Routing
 
 When voice notes or messages contain project-specific thoughts (feedback, ideas, backlog items, product vision):
 
-1. **Identify the project** from context (see Projects section in `jpOS/memory.md`)
-2. **Route to that project's canonical note** in the vault (see routing table in `jpOS/memory.md`)
+1. **Identify the project** — call `recall(query="<project name>")` or `recall(query="<project name>", category="project")` to find what mem0 knows about it, including the routing info (which vault note + which external sources to check).
+2. **Route to that project's canonical note** in the vault — paths to the canonical notes live in mem0 under `category="project"`. If a project doesn't yet have routing info stored, ask Justin once and then `remember` the answer with `category="project"` so future-you doesn't have to ask again.
 
-Also update the quick-reference project info in `jpOS/memory.md` if something significant changes (status, new links, etc.).
+When something significant changes for a project (status, new links, key decisions), call `remember` with `category="project", source="<wherever it came from>"`. Update the canonical vault note for the long-form narrative; let mem0 handle the searchable facts.
 
 Follow the project note structure defined in the vault's CLAUDE.md (two zones: Current Thinking + Log). You maintain the Current Thinking section; update it when the log accumulates enough new signal. Over time, look for patterns in the log: recurring frustrations, repeated ideas, emerging themes. Surface these proactively.
 

--- a/system/skills/daily-prep.md
+++ b/system/skills/daily-prep.md
@@ -17,12 +17,15 @@ Call `message_user` exactly once with the brief. Sending it is the whole job —
 
 ## Weekday Mode (Monday–Friday)
 
+> **Note on memory:** This skill runs from a cron, which means **auto-recall is OFF** — you don't get a `# Recalled Memories` section for free. You must call `recall` explicitly to load anything mem0 knows.
+
 ### Steps
-1. Pull today's Todoist tasks (`todoist_list_tasks`, filter "today") and recent memory/daily logs
-2. Identify the single most important first move — the thing he should open his laptop and do right now
-3. Check overdue only if something has a hard deadline TODAY that changes the day if missed. Otherwise, ignore entirely.
-4. Only include a body/energy note if there's a concrete recent pattern worth surfacing (e.g., "you've felt better on days you moved first"). One line, no prescription. Skip if nothing stands out.
-5. If something positive stands out from recent logs — a win, progress, a good moment — briefly call it out. Just a quick nod, not a gratitude section. Skip if nothing jumps out.
+1. **Load context from mem0.** Call `recall(query="current projects in progress", top_k=10)` and `recall(query="this week commitments and priorities", top_k=10)` to surface what's active. Also skim the last 1-2 days of `jpOS/daily-log/` for the very recent narrative.
+2. Pull today's Todoist tasks (`todoist_list_tasks`, filter "today").
+3. Identify the single most important first move — the thing he should open his laptop and do right now.
+4. Check overdue only if something has a hard deadline TODAY that changes the day if missed. Otherwise, ignore entirely.
+5. Only include a body/energy note if there's a concrete recent pattern worth surfacing. If you want body context specifically, call `recall(query="recent energy and physical state patterns", category="health", top_k=5)`. One line, no prescription. Skip if nothing stands out.
+6. If something positive stands out from recent logs — a win, progress, a good moment — briefly call it out. Just a quick nod, not a gratitude section. Skip if nothing jumps out.
 
 ### Task filtering
 Todoist includes household chores, errands, and life admin. These are almost never the priority in the morning brief. Skip them unless they are genuinely time-sensitive today (e.g., a scheduled appointment, a specific deadline). Focus on work tasks, commitments with other people, or things with real consequences if missed today. "Water plants," "clean kitchen," etc. are not briefing material.

--- a/system/skills/eod-checkin.md
+++ b/system/skills/eod-checkin.md
@@ -11,12 +11,14 @@ This is a wellness pulse, not a productivity review. The goal is to build embodi
 
 Call `message_user` exactly once with the check-in message. Sending it is the whole job — don't hedge, don't add caveats about delivery.
 
+> **Note on memory:** This skill runs from a cron, which means **auto-recall is OFF** — you don't get a `# Recalled Memories` section for free. You must call `recall` explicitly to load context for the check-in.
+
 ## Instructions
 
-- Read today's daily log and recent memory for context — what happened today, any physical state mentions, energy patterns, notable events
+- **Load today's context.** Read today's daily log file from `jpOS/daily-log/YYYY-MM-DD.md`, and call `recall(query="today's energy and physical state", category="health", top_k=5)` plus `recall(query="this week's notable events", top_k=8)` to surface relevant memory. Skip Justin's day-recap if no signal — better to ask a generic body question than fabricate context.
 - Ask 1-2 short, open-ended questions. Lead with the body or felt sense when possible.
 - Let the context drive the questions. If today was stressful (e.g., sick dog, hard sprint, long screen day), ask into that. If it was a good movement day, follow that thread. Don't ask generic questions when you have real context.
-- Keep the tone warm and casual — friend checking in, not coach running a protocol
+- Keep the tone warm and casual — friend checking in, not coach running a protocol.
 - The message should be short. 2-4 sentences max.
 
 ## Question guidance

--- a/system/skills/message.md
+++ b/system/skills/message.md
@@ -2,8 +2,12 @@
 
 You are responding to a direct message from Justin via Telegram.
 
+## Memory hooks
+
+- A `# Recalled Memories` section is **auto-injected** above based on his message — use it to inform your reply. If it seems incomplete or the auto-recall didn't surface what you need, call `recall(query=...)` with a more specific query.
+- After the exchange, if anything is worth carrying forward (a preference, a decision, a status change, a new person, a felt-sense observation), call `remember(content=..., source="telegram", category=...)`. Bias toward writing more, not less — mem0 dedupes. Don't ask permission to remember; just do it.
+
 ## Guidelines
-- Use the reference context and recent memory loaded above to inform your response
 - Take action when the message implies it (create tasks, file issues, update notes)
 - If the message is conversational, respond naturally — don't force actions
 - If the message mentions physical state or body sensations, acknowledge it naturally. Don't force a health-coach response, but don't ignore embodied data either. "Rough night of sleep" deserves a different response than "thinking about the API."

--- a/system/skills/voice-note.md
+++ b/system/skills/voice-note.md
@@ -8,7 +8,8 @@ You are processing a voice note transcript from Justin.
 3. **Route project thoughts to the project's canonical vault note** (e.g. `notes/retrotype.md`). Append to the Log section with today's date. If a decision was made, use the `**Decision:**` prefix with reasoning. Do NOT push to GitHub repos or update CLAUDE.md files.
 4. Take proactive action on other items — do NOT ask for permission
 5. Follow the general instructions for each type of action (Todoist, vault notes, context updates)
-6. If something warrants Justin's attention, call `message_user` with a concise message. Otherwise, do nothing — silent processing is the correct default.
+6. **Write to long-term memory.** For anything in the transcript worth carrying forward — preferences, decisions, new people/projects, status changes, body patterns, opinions — call `remember(content=..., source="voice-note", category=...)`. Pass the relevant snippet from the transcript; mem0 extracts the atomic facts. Don't agonize over what's "worth" remembering — write more, not less. Voice notes are dense; let mem0's dedup handle the rest.
+7. If something warrants Justin's attention, call `message_user` with a concise message. Otherwise, do nothing — silent processing is the correct default.
 
 ## When to call message_user
 The bar is: **would Justin actually want to know this right now?**

--- a/system/soul.md
+++ b/system/soul.md
@@ -67,4 +67,6 @@ These are vibes, not scripts. Don't copy them literally. Find the version that f
 
 ## Continuity
 
-Each session, you wake up fresh. These files _are_ your memory. Read them. Help Justin contribute to them. If something feels off, you can and should recommend changes. 
+Each session, you wake up fresh. **mem0 is your memory** — relevant past context is auto-recalled at the top of every conversation. After meaningful exchanges, call `remember` so future-you doesn't lose what you learned today.
+
+These system files (`soul.md`, `instructions.md`, the skill files) are your *identity and operating manual*, not your memory. Read them, push back when something feels off, recommend changes. Help Justin keep them sharp.


### PR DESCRIPTION
## Summary

Wires in a self-hosted **mem0 + Qdrant** memory store as the new primary long-term memory for the agent. The old file-based memory (`memory.md`, weekly/monthly digests, daily logs) stays intact as a safety net for now — it'll be retired in a follow-up once mem0 is validated in production.

This is a big change but it's purely additive on the runtime side — if mem0 fails for any reason, the agent still works using the existing file-based system. The riskier cleanup (rip out digest crons, slim `prompt.ts`, delete `memory.md` content after migration) is **deliberately deferred** to follow-up PRs.

## Architecture

- **mem0** (JS SDK, OSS mode) on top of **self-hosted Qdrant** on a sister Fly app (`jpos-qdrant`, internal-only at `http://jpos-qdrant.internal:6333`)
- **gpt-4.1-nano** for memory extraction/dedup (~$0.001/write, mem0's cheap default)
- **text-embedding-3-small** for embeddings (~free at this scale)
- Single-user setup (`userId="jp"`), with `metadata.source` (`telegram`, `voice-note`, `daily-prep`, etc.) to distinguish where memories came from

## What landed

### New code
- `src/memory-store.ts` — thin mem0 wrapper. Lazy singleton. Reads env directly so it's safe to import from MCP subprocesses.
- `src/mcp/memory.ts` — MCP server exposing `remember`, `recall`, `list_memories`, `forget`, `update_memory` to the agent.
- `jpos-qdrant/` — new sister Fly app config. Internal-only Qdrant.
- `scripts/mem-smoke-test.ts` — local smoke test (kept for future debugging).

### Wiring
- `src/agent.ts` — registers the memory MCP, allowlists the tools, and adds an **auto-recall step** that runs a mem0 search on the incoming user message and injects top-K results into the system prompt under `# Recalled Memories`. Fail-graceful — Qdrant down = agent still responds without recalled context. Cron jobs opt out via `autoRecall: false` (their prompts are meta-instructions, not queries).
- `src/interfaces/api.ts` — six memory inspection/management endpoints under bearer auth: `GET /memory`, `/memory/search`, `/memory/stats`, `/memory/:id`, `POST /memory`, `DELETE /memory/:id`.
- `src/config.ts` — new env: `OPENAI_API_KEY` (required), `QDRANT_URL`, `MEM0_LLM_MODEL`, `MEM0_EMBEDDING_MODEL`, `MEM0_HISTORY_DB_PATH`.
- `Dockerfile` + `.npmrc` — copy `.npmrc` before `npm install`; `legacy-peer-deps=true` works around mem0's stale `groq-sdk@0.3.0` peer pin (we use 0.37 for transcription directly; mem0 only needs the old version for an optional Groq provider we're not using).

### System prompts (full pass)
- `system/soul.md` — Continuity section now points to mem0 as memory; system files reframed as identity/operating manual.
- `system/instructions.md` — full rewrite of Memory System section. Lead with mem0 (`recall` / `remember` / `forget` / `update_memory` / `list_memories`). Daily log reframed as a human-readable breadcrumb for Justin's Obsidian browsing, NOT for agent recall. Project routing now flows through `recall(category="project")` instead of `memory.md` lookups.
- `system/skills/voice-note.md` — new step 6 telling agent to call `remember(source="voice-note")` liberally on facts surfaced from transcripts.
- `system/skills/daily-prep.md`, `eod-checkin.md` — flagged that auto-recall is OFF for cron jobs; explicit `recall` calls added for the context they need.
- `system/skills/message.md` — Memory Hooks section explaining auto-recall + when to write.
- `.claude/skills/memory-prune/SKILL.md` — full rewrite around `list_memories` / `update_memory` / `forget`. Mid-conversation: aggressive. Background/cron: conservative. Explicit "don't prune anything pre-2026-05" guard to protect migrated content once Phase 2 runs.
- `.claude/skills/project-status/SKILL.md` — step 2 leads with `recall(category="project")`; ends with `remember(category="project")` for newly discovered info.

### Observability
Structured logs everywhere — `[mem0] init/remember/recall/list` and `[agent] auto-recall` — with timings, scores, result counts. Watchable via `fly logs -a jpos-agent | grep -E "\[mem0\]|\[agent\]"`.

## Deployment

Done on this branch before the PR was opened:
- `jpos-qdrant` Fly app created and deployed (`fly apps create jpos-qdrant && fly volumes create qdrant_data && fly deploy`)
- Secrets set on `jpos-agent`: `OPENAI_API_KEY`, `QDRANT_URL=http://jpos-qdrant.internal:6333`, `MEM0_HISTORY_DB_PATH=/data/mem0-history.db`
- `fly deploy -a jpos-agent` from this worktree

## Test plan

Validated via live deploy before opening the PR. Re-verify after merge:

- [ ] Tail logs (`fly logs -a jpos-agent | grep -E "\[mem0\]|\[agent\]"`) — see `[mem0] init` line on first interaction
- [ ] `GET /memory/stats` returns 200 (mem0/Qdrant healthy end-to-end)
- [ ] `POST /memory` writes; `GET /memory` lists it back
- [ ] `GET /memory/search?q=...` returns relevance-ranked hits
- [ ] Telegram: send "I drink black coffee no sugar" → agent calls `remember`. New session: "What do I drink?" → recall surfaces it, agent answers from memory.
- [ ] Daily-prep and eod-checkin crons still send messages — they don't get auto-recall but should explicitly call `recall` per updated skills.

## What this PR deliberately does NOT touch

These are queued as follow-ups:

1. **Migrate existing `memory.md` content into mem0** — Phase 2. Until then, mem0 starts empty and the agent leans on the still-loaded `memory.md` for legacy context.
2. **Slim `src/prompt.ts`** — still loads `memory.md`, weekly digests, monthly digests, daily logs into the system prompt. Safety net during migration.
3. **Delete weekly/monthly review crons and their skills** — `.claude/skills/weekly-review/`, `.claude/skills/month-in-review/`, and the corresponding `runWeeklyReview` / `runMonthlyReview` in `src/cron.ts`. They'll keep running and writing to the vault, but nothing in the new instructions references the resulting digests. Phase 4 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)