### PR TITLE
Drop mem0 — replace with thin Qdrant + OpenAI memory store

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,26 +34,27 @@ CLI tools (invoked via Bash) are more token-efficient than MCP tool definitions 
 - `src/agent.ts` - Agent SDK wrapper with session management + auto-recall step
 - `src/prompt.ts` - Builds system prompt from repo system files + vault memory
 - `src/memory.ts` - **(legacy, being phased out)** File-based reader for vault digests/daily logs
-- `src/memory-store.ts` - **mem0 + Qdrant memory store.** Primary memory layer.
+- `src/memory-store.ts` - **Qdrant + OpenAI memory store.** Primary memory layer.
 - `src/interfaces/telegram.ts` - Telegram bot (grammy)
 - `src/interfaces/api.ts` - HTTP API (Fastify) + memory inspection endpoints
 - `src/mcp/memory.ts` - Memory MCP server (`remember`, `recall`, `list_memories`, `forget`, `update_memory`)
 - `src/mcp/todoist.ts` - Todoist MCP server
 - `src/obsidian.ts` - Git operations for Obsidian vault
 
-## Memory layer (mem0 + Qdrant)
+## Memory layer (Qdrant + OpenAI)
 
-The agent's long-term memory uses [mem0](https://github.com/mem0ai/mem0) backed by a self-hosted Qdrant vector store on Fly.
+The agent's long-term memory is a thin wrapper (~300 LOC in `src/memory-store.ts`) over a self-hosted Qdrant vector store and OpenAI embeddings. We previously tried mem0 here but ripped it out after their JS bundle's eager-import-every-provider design forced ~150 unused transitive deps.
 
 - **Vector store:** Qdrant — separate Fly app `jpos-qdrant`, reachable internally at `http://jpos-qdrant.internal:6333`. See `jpos-qdrant/README.md` for setup.
-- **LLM (for fact extraction + dedup):** `gpt-4.1-nano` via OpenAI (cheap; ~$0.001/write). Configurable via `MEM0_LLM_MODEL`.
-- **Embeddings:** `text-embedding-3-small` via OpenAI. Configurable via `MEM0_EMBEDDING_MODEL`.
-- **History DB:** SQLite at `/data/mem0-history.db` on Fly (tracks add/update/delete events).
-- **Single-user:** all memories written under `userId = "jp"`; use `metadata.source` (voice-note, telegram, daily-prep, etc.) to distinguish origin.
+- **Embeddings:** `text-embedding-3-small` via OpenAI (1536 dims). Configurable via `MEMORY_EMBEDDING_MODEL`.
+- **Dedup LLM:** `gpt-4.1-nano` via OpenAI — one call per `remember()` to decide ADD vs REPLACE vs NOOP against the top-K nearest existing memories (threshold 0.85 cosine). Configurable via `MEMORY_DEDUP_MODEL`.
+- **No extraction:** the agent is responsible for passing clean atomic facts to `remember`; the store doesn't extract or rewrite content. See `system/instructions.md`.
+- **Single-user:** all memories written under `userId = "jp"` (Qdrant payload field); use `source` (voice-note, telegram, daily-prep, etc.) and `category` payload fields to distinguish/filter.
+- **No history DB:** simpler than mem0; if we want change history later we can add it as another collection.
 
 ### Auto-recall
 
-`runAgent()` does a top-K (default 5) mem0 search on the incoming user message and injects results into the system prompt under a `# Recalled Memories` section. Fail-graceful: if Qdrant is down, the agent still responds without recalled context. Opt out by passing `autoRecall: false` (used for all cron jobs — their prompts are meta-instructions, not queries).
+`runAgent()` embeds the incoming user message, searches Qdrant for top-K (default 5), and injects results into the system prompt under a `# Recalled Memories` section. Fail-graceful: if Qdrant is down, the agent still responds without recalled context. Opt out by passing `autoRecall: false` (used for all cron jobs — their prompts are meta-instructions, not queries).
 
 ### Inspecting memory
 
@@ -67,11 +68,10 @@ The HTTP API exposes (Bearer-token auth):
 
 ### Required env vars
 
-- `OPENAI_API_KEY` (required) — for embeddings + mem0's extraction LLM
+- `OPENAI_API_KEY` (required) — for embeddings and the dedup LLM
 - `QDRANT_URL` (default `http://localhost:6333`; on Fly set to `http://jpos-qdrant.internal:6333`)
-- `MEM0_LLM_MODEL` (default `gpt-4.1-nano`)
-- `MEM0_EMBEDDING_MODEL` (default `text-embedding-3-small`)
-- `MEM0_HISTORY_DB_PATH` (default `./mem0-history.db`; on Fly set to `/data/mem0-history.db`)
+- `MEMORY_EMBEDDING_MODEL` (default `text-embedding-3-small`)
+- `MEMORY_DEDUP_MODEL` (default `gpt-4.1-nano`)
 
 ## System Prompts (in this repo)
 

--- a/.claude/skills/memory-prune/SKILL.md
+++ b/.claude/skills/memory-prune/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: memory-prune
-description: Review mem0 long-term memory for stale, outdated, or redundant entries and prune them. Run periodically or on demand to keep memory clean and current.
+description: Review long-term memory for stale, outdated, or redundant entries and prune them. Run periodically or on demand to keep memory clean and current.
 ---
 
 # Memory Prune
 
-Review long-term memory in mem0 and remove or update entries that are stale, outdated, redundant, contradicted, or no longer useful. mem0's automatic dedup catches the obvious overlaps on write, but it doesn't catch things that have gone stale over time — that's what this skill is for.
+Review long-term memory and remove or update entries that are stale, outdated, redundant, contradicted, or no longer useful. The memory store's automatic dedup catches the obvious overlaps on write, but it doesn't catch things that have gone stale over time — that's what this skill is for.
 
 ## Steps
 
@@ -18,7 +18,7 @@ Review long-term memory in mem0 and remove or update entries that are stale, out
    - **Outdated**: facts that have changed (old project status, shifted goals, abandoned preferences)
    - **Contradicted**: directly conflicts with a newer memory and the newer one is correct
    - **Redundant**: duplicated by another memory that says the same thing more clearly
-   - **Too granular**: hyper-specific details from a one-time event that don't need to persist (mem0's extractor occasionally over-stores)
+   - **Too granular**: hyper-specific details from a one-time event that don't need to persist
 
 4. **Act on each flag:**
    - **Update** an outdated fact: `update_memory(memory_id, new_content)` — preferred over delete+rewrite for facts that just changed.
@@ -36,7 +36,7 @@ Review long-term memory in mem0 and remove or update entries that are stale, out
 
 **Background / cron (no active conversation):**
 - Do NOT message Justin. Silent processing.
-- Be **conservative** — when in doubt, keep it. A slightly bloated mem0 is better than accidentally deleting something that matters.
+- Be **conservative** — when in doubt, keep it. A slightly bloated the memory store is better than accidentally deleting something that matters.
 - Only prune things you're confident are stale: finished projects still appearing as active, people/contexts that haven't shown up in logs for months, clearly outdated preferences.
 - Append a one-line note to today's daily log so there's a record of what was pruned.
 
@@ -45,5 +45,5 @@ Review long-term memory in mem0 and remove or update entries that are stale, out
 - **Identity-level facts** (personality, core preferences, long-term goals) — even if not recently referenced.
 - **Relationship context** (who people are, how Justin relates to them) — unless you're confident the relationship is no longer relevant.
 - **Project routing info** (which vault note, which repo, which Linear workspace) — even for paused projects, keep it until the project is explicitly archived.
-- **Anything pre-2026-05** that came from the initial migration of `memory.md` — these were promoted to mem0 with intent; don't second-guess them in early passes.
+- **Anything pre-2026-05** that came from the initial migration of `memory.md` — these were promoted to the memory store with intent; don't second-guess them in early passes.
 - **Anything you're unsure about** — when running in background, always err on the side of keeping.

--- a/.claude/skills/project-status/SKILL.md
+++ b/.claude/skills/project-status/SKILL.md
@@ -12,15 +12,15 @@ Pull the current state of a project from all available sources and synthesize a 
 
 1. **Identify the project.** Use `$ARGUMENTS` if provided, or infer from conversation context.
 
-2. **Pull what mem0 knows about the project first.** Routing info (vault note path, repo, Linear workspace) and recent state live here:
+2. **Pull what the memory store knows about the project first.** Routing info (vault note path, repo, Linear workspace) and recent state live here:
    - `recall(query="<project name> routing canonical note repo workspace", category="project", top_k=10)` — gets routing + structural info
    - `recall(query="<project name> current status recent activity decisions", top_k=15)` — gets recent state, decisions, blockers
-   - If mem0 returns nothing useful, the project hasn't been captured yet — ask Justin and then `remember` what he tells you so the next call is easier.
+   - If the memory store returns nothing useful, the project hasn't been captured yet — ask Justin and then `remember` what he tells you so the next call is easier.
 
 3. **Gather from external sources** (use the routing info from step 2; check each, skip what doesn't exist):
 
    **Obsidian vault:**
-   - Read the project's canonical note (path from mem0)
+   - Read the project's canonical note (path from the memory store)
    - Check the "Current Thinking" and "Log" sections for recent state
 
    **GitHub:**
@@ -52,5 +52,5 @@ If something is unclear or you're curious about context you can't find, ask. Jus
 ## Notes
 
 - Not every project has every source. A hobby shader project won't have Linear issues. A work project might not have a vault note yet. Work with what's available.
-- If you can't find the project at all, say so and ask Justin for pointers — this signals that the routing info isn't in mem0 yet.
-- When you discover new project info (a repo URL, a status change, a new link), call `remember(content=..., source=..., category="project")`. Don't wait for permission — mem0 dedupes so over-writing is cheap.
+- If you can't find the project at all, say so and ask Justin for pointers — this signals that the routing info isn't in the memory store yet.
+- When you discover new project info (a repo URL, a status change, a new link), call `remember(content=..., source=..., category="project")`. Don't wait for permission — the memory store dedupes so over-writing is cheap.

--- a/.env.example
+++ b/.env.example
@@ -22,22 +22,19 @@ GROQ_API_KEY=your-groq-api-key
 # Ramble Webhook Secret (optional - copy from Ramble app Settings screen)
 RAMBLE_WEBHOOK_SECRET=your-ramble-webhook-secret
 
-# OpenAI API Key (required — used by mem0 for embeddings and the extraction LLM)
+# OpenAI API Key (required — used for embeddings + dedup LLM)
 OPENAI_API_KEY=your-openai-api-key
 
-# Qdrant vector store URL (defaults to http://localhost:6333 for local dev;
-# in production set to http://jpos-qdrant.internal:6333)
+# Qdrant vector store URL. Default localhost:6333 for local dev;
+# in production set to http://jpos-qdrant.internal:6333
 QDRANT_URL=http://localhost:6333
 
-# mem0 LLM model (defaults to gpt-4.1-nano — cheap fact extraction/dedup)
-MEM0_LLM_MODEL=gpt-4.1-nano
+# Embedding model (default text-embedding-3-small, 1536 dims)
+MEMORY_EMBEDDING_MODEL=text-embedding-3-small
 
-# mem0 embedding model (defaults to text-embedding-3-small)
-MEM0_EMBEDDING_MODEL=text-embedding-3-small
-
-# mem0 history SQLite path (tracks add/update/delete events on memories)
-# Default: ./mem0-history.db (local), use /data/mem0-history.db on Fly.io
-MEM0_HISTORY_DB_PATH=./mem0-history.db
+# Dedup LLM model — used once per remember() to decide ADD vs REPLACE vs NOOP
+# against near-neighbor existing memories. Default gpt-4.1-nano (cheapest).
+MEMORY_DEDUP_MODEL=gpt-4.1-nano
 
 # Server Port
 PORT=3000

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ ENV PATH="/root/.claude/bin:${PATH}"
 WORKDIR /app
 
 # Copy package files and install dependencies
-# .npmrc enables legacy-peer-deps for mem0's stale groq-sdk pin
-COPY package*.json .npmrc ./
+COPY package*.json ./
 RUN npm install
 
 # Copy source and build

--- a/jpos-qdrant/fly.toml
+++ b/jpos-qdrant/fly.toml
@@ -1,4 +1,4 @@
-# Fly.io configuration for jpOS Qdrant — vector store for mem0.
+# Fly.io configuration for jpOS Qdrant — vector store for the memory layer.
 #
 # Internal-only: not exposed to the public internet. Reachable from
 # jpos-agent over Fly's private network at:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,13 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",
         "@fastify/bearer-auth": "^9.4.0",
+        "@qdrant/js-client-rest": "^1.13.0",
         "dotenv": "^16.4.1",
         "fastify": "^4.26.0",
         "grammy": "^1.41.1",
         "groq-sdk": "^0.37.0",
-        "mem0ai": "^3.0.3",
-        "node-cron": "^3.0.3"
+        "node-cron": "^3.0.3",
+        "openai": "^4.93.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -48,10 +49,74 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -59,6 +124,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -115,9 +516,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -125,9 +526,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -156,9 +557,9 @@
       }
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -171,9 +572,9 @@
       }
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -221,10 +622,9 @@
       }
     },
     "node_modules/@grammyjs/types": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.25.0.tgz",
-      "integrity": "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==",
-      "license": "MIT"
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.26.0.tgz",
+      "integrity": "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -242,9 +642,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -252,9 +652,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -304,6 +704,27 @@
         "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
@@ -315,6 +736,219 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -359,6 +993,31 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
     },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.18.0.tgz",
+      "integrity": "sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "undici": "^6.24.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "pnpm": ">=8"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -366,9 +1025,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -585,9 +1244,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true
     },
     "node_modules/abort-controller": {
@@ -607,9 +1266,9 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -639,9 +1298,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -671,9 +1330,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -686,9 +1345,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -766,16 +1425,6 @@
         "fastq": "^1.17.1"
       }
     },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -783,9 +1432,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1017,9 +1666,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1029,32 +1678,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1154,9 +1803,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1164,9 +1813,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1306,9 +1955,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1337,9 +1986,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1489,29 +2138,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -1559,6 +2189,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1603,9 +2247,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -1618,7 +2262,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -1648,9 +2292,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1658,9 +2302,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1716,12 +2360,11 @@
       }
     },
     "node_modules/grammy": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.41.1.tgz",
-      "integrity": "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==",
-      "license": "MIT",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
+      "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
       "dependencies": {
-        "@grammyjs/types": "3.25.0",
+        "@grammyjs/types": "3.26.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
@@ -1798,9 +2441,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2017,62 +2660,6 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mem0ai": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mem0ai/-/mem0ai-3.0.3.tgz",
-      "integrity": "sha512-nKwGYNh8DipG9Sw0ik/huFLpKtVtwadSy+T6GjAxkkrHp6hO3tlbR75EWH/bCGDG/HO06nYDsDP5fPSnj3bp5g==",
-      "dependencies": {
-        "axios": "1.13.6",
-        "openai": "^4.93.0",
-        "uuid": "9.0.1",
-        "zod": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.40.1",
-        "@azure/identity": "^4.0.0",
-        "@azure/search-documents": "^12.0.0",
-        "@cloudflare/workers-types": "^4.20250504.0",
-        "@google/genai": "^1.2.0",
-        "@langchain/core": "^1.0.0",
-        "@mistralai/mistralai": "^1.5.2",
-        "@qdrant/js-client-rest": "1.13.0",
-        "@supabase/supabase-js": "^2.49.1",
-        "@types/jest": "29.5.14",
-        "@types/pg": "8.11.0",
-        "better-sqlite3": "^12.6.2",
-        "cloudflare": "^4.2.0",
-        "compromise": "^14.0.0",
-        "groq-sdk": "0.3.0",
-        "natural": "^8.0.1",
-        "ollama": "^0.5.14",
-        "pg": "8.11.3",
-        "redis": "^4.6.13"
-      }
-    },
-    "node_modules/mem0ai/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/mem0ai/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/merge2": {
@@ -2346,9 +2933,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -2431,11 +3018,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2588,9 +3170,9 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2634,9 +3216,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -2783,13 +3365,20 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -2810,6 +3399,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2876,6 +3466,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "fastify": "^4.26.0",
     "grammy": "^1.41.1",
     "groq-sdk": "^0.37.0",
-    "mem0ai": "^3.0.3",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "@qdrant/js-client-rest": "^1.13.0",
+    "openai": "^4.93.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/scripts/mem-smoke-test.ts
+++ b/scripts/mem-smoke-test.ts
@@ -1,5 +1,5 @@
 /**
- * End-to-end smoke test for the mem0 + Qdrant memory store.
+ * End-to-end smoke test for the Qdrant + OpenAI memory store.
  *
  * Prereqs:
  *   1. Qdrant running on localhost:6333
@@ -28,39 +28,49 @@ function divider(title: string) {
 }
 
 async function main() {
-  console.log(`Collection: ${COLLECTION_NAME}`);
-  console.log(`User ID:    ${JPOS_USER_ID}`);
-  console.log(`Qdrant URL: ${process.env.QDRANT_URL || "http://localhost:6333 (default)"}`);
-  console.log(`LLM model:  ${process.env.MEM0_LLM_MODEL || "gpt-4.1-nano (default)"}`);
+  console.log(`Collection:    ${COLLECTION_NAME}`);
+  console.log(`User ID:       ${JPOS_USER_ID}`);
+  console.log(`Qdrant URL:    ${process.env.QDRANT_URL || "http://localhost:6333 (default)"}`);
+  console.log(`Embed model:   ${process.env.MEMORY_EMBEDDING_MODEL || "text-embedding-3-small (default)"}`);
+  console.log(`Dedup model:   ${process.env.MEMORY_DEDUP_MODEL || "gpt-4.1-nano (default)"}`);
 
-  // --- 1. Write a couple memories ----------------------------------------
+  // --- 1. Write a few atomic facts ---------------------------------------
   divider("1. remember() — store a few facts");
 
   const r1 = await remember({
-    content: "I prefer dark mode in all my apps. Bright white screens hurt my eyes.",
+    content: "User prefers dark mode in all his apps. Bright white screens hurt his eyes.",
     source: "smoke-test",
     category: "preference",
   });
-  console.log(`Wrote ${r1.length} memories from preference note:`);
+  console.log(`Wrote ${r1.length} memories from preference fact:`);
   r1.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
 
   const r2 = await remember({
     content:
-      "Working on jpOS — my personal AI agent on Fly.io with Telegram + HTTP interfaces. " +
-      "Currently rebuilding the memory layer around mem0 + Qdrant.",
+      "Justin is rebuilding jpOS's memory layer around a thin Qdrant + OpenAI wrapper " +
+      "(dropping mem0).",
     source: "smoke-test",
     category: "project",
   });
-  console.log(`\nWrote ${r2.length} memories from project note:`);
+  console.log(`\nWrote ${r2.length} memories from project fact:`);
   r2.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
 
   const r3 = await remember({
-    content: "I drink black coffee every morning, no sugar, no milk.",
+    content: "Justin drinks black coffee every morning, no sugar, no milk.",
     source: "smoke-test",
     category: "preference",
   });
-  console.log(`\nWrote ${r3.length} memories from coffee note:`);
+  console.log(`\nWrote ${r3.length} memories from coffee fact:`);
   r3.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
+
+  // Re-write a near-duplicate to exercise the dedup path
+  const r4 = await remember({
+    content: "User likes black coffee with no sugar in the morning.",
+    source: "smoke-test",
+    category: "preference",
+  });
+  console.log(`\nWrote ${r4.length} memories from near-duplicate (should NOOP or REPLACE):`);
+  r4.forEach((m) => console.log(`  [${m.id.slice(0, 8)}] ${m.memory}`));
 
   // --- 2. Search ----------------------------------------------------------
   divider("2. recall() — semantic search");

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,9 +18,9 @@ interface RunAgentParams {
   externalId: string;
   systemContext?: string;
   /**
-   * Whether to auto-recall relevant memories from mem0 based on `prompt`
-   * and inject them into the system prompt. Defaults to true.
-   * Set false for cron jobs where the prompt is an instruction, not a query.
+   * Whether to auto-recall relevant memories based on `prompt` and inject
+   * them into the system prompt. Defaults to true. Set false for cron jobs
+   * where the prompt is an instruction, not a query.
    */
   autoRecall?: boolean;
   /** Max memories to surface in auto-recall. Defaults to 5. */
@@ -32,9 +32,10 @@ interface RunAgentParams {
 }
 
 /**
- * Search mem0 for memories relevant to `prompt` and format them as a
- * system-prompt section. Returns empty string if mem0 is unreachable or returns
- * no hits — the agent should still respond, just without recalled context.
+ * Search the memory store for memories relevant to `prompt` and format them
+ * as a system-prompt section. Returns empty string if the store is unreachable
+ * or returns no hits — the agent should still respond, just without recalled
+ * context.
  */
 async function autoRecallSection(prompt: string, topK: number): Promise<string> {
   try {
@@ -80,8 +81,8 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
   let sessionId: string | undefined = existingSession?.agentSessionId;
   let result = "";
 
-  // Auto-recall: surface relevant memories from mem0 and append to systemContext.
-  // Fail-graceful — if mem0/Qdrant is down, agent still runs without recalled context.
+  // Auto-recall: surface relevant memories and append to systemContext.
+  // Fail-graceful — if Qdrant is down, agent still runs without recalled context.
   let finalSystemContext = systemContext;
   if (autoRecall && prompt && prompt.trim().length > 0) {
     const recallSection = await autoRecallSection(prompt, autoRecallTopK);
@@ -120,9 +121,8 @@ export async function runAgent(params: RunAgentParams): Promise<AgentResponse> {
       env: {
         OPENAI_API_KEY: env.openaiApiKey,
         QDRANT_URL: env.qdrantUrl,
-        MEM0_LLM_MODEL: env.mem0LlmModel,
-        MEM0_EMBEDDING_MODEL: env.mem0EmbeddingModel,
-        MEM0_HISTORY_DB_PATH: env.mem0HistoryDbPath,
+        MEMORY_EMBEDDING_MODEL: env.memoryEmbeddingModel,
+        MEMORY_DEDUP_MODEL: env.memoryDedupModel,
       },
     },
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,12 +31,11 @@ export const env = {
   groqApiKey: requireEnv("GROQ_API_KEY"),
   rambleWebhookSecret: process.env.RAMBLE_WEBHOOK_SECRET || "",
   port: parseInt(process.env.PORT || "3000", 10),
-  // mem0 memory layer (Qdrant vector store + OpenAI for LLM + embeddings)
+  // Memory layer (Qdrant vector store + OpenAI embeddings + dedup LLM)
   openaiApiKey: requireEnv("OPENAI_API_KEY"),
   qdrantUrl: process.env.QDRANT_URL || "http://localhost:6333",
-  mem0LlmModel: process.env.MEM0_LLM_MODEL || "gpt-4.1-nano",
-  mem0EmbeddingModel: process.env.MEM0_EMBEDDING_MODEL || "text-embedding-3-small",
-  mem0HistoryDbPath: process.env.MEM0_HISTORY_DB_PATH || "./mem0-history.db",
+  memoryEmbeddingModel: process.env.MEMORY_EMBEDDING_MODEL || "text-embedding-3-small",
+  memoryDedupModel: process.env.MEMORY_DEDUP_MODEL || "gpt-4.1-nano",
   // App Store Connect (optional - tools disabled if not set)
   appStoreConnectKeyId: process.env.APP_STORE_CONNECT_KEY_ID || "",
   appStoreConnectIssuerId: process.env.APP_STORE_CONNECT_ISSUER_ID || "",

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -178,12 +178,12 @@ export async function createApiServer() {
 
     // Manual write (mostly for debugging / seeding)
     app.post<{
-      Body: { content: string; source?: string; category?: string; infer?: boolean };
+      Body: { content: string; source?: string; category?: string; skipDedup?: boolean };
     }>("/memory", async (request, reply) => {
-      const { content, source, category, infer } = request.body;
+      const { content, source, category, skipDedup } = request.body;
       if (!content) return reply.status(400).send({ error: "content required" });
       try {
-        const memories = await remember({ content, source, category, infer });
+        const memories = await remember({ content, source, category, skipDedup });
         return { added: memories.length, memories };
       } catch (error) {
         return reply.status(500).send({

--- a/src/mcp/memory.ts
+++ b/src/mcp/memory.ts
@@ -2,15 +2,15 @@
 /**
  * Memory MCP Server
  *
- * Exposes the mem0-backed memory store to the agent as tool calls:
- *   - remember:      store something to long-term memory
+ * Exposes the Qdrant-backed memory store to the agent as tool calls:
+ *   - remember:      store an atomic fact to long-term memory
  *   - recall:        semantic search over past memories
  *   - list_memories: list recent / filtered memories
  *   - forget:        delete a memory by id
  *   - update_memory: rewrite a memory's content
  *
- * Env: OPENAI_API_KEY (required), QDRANT_URL, MEM0_LLM_MODEL,
- * MEM0_EMBEDDING_MODEL, MEM0_HISTORY_DB_PATH.
+ * Env: OPENAI_API_KEY (required), QDRANT_URL, MEMORY_EMBEDDING_MODEL,
+ * MEMORY_DEDUP_MODEL.
  */
 
 import {
@@ -25,16 +25,19 @@ const tools = [
   {
     name: "remember",
     description:
-      "Store something to long-term memory. Use when the user shares a preference, " +
-      "fact about themselves, a decision, a commitment, or anything you should know " +
-      "in future conversations. mem0 will extract atomic facts from the content unless " +
-      "infer=false (in which case the content is stored verbatim as a single memory).",
+      "Store an atomic fact to long-term memory. Pass a single well-formed fact " +
+      "in third person (e.g. \"User prefers dark mode\"), not raw conversation text " +
+      "or multiple facts in one call. On write, the store searches for near-duplicates " +
+      "and asks an LLM whether to ADD (default), REPLACE an existing memory with this " +
+      "clearer/updated version, or NOOP if it's already captured.",
     inputSchema: {
       type: "object",
       properties: {
         content: {
           type: "string",
-          description: "The raw text or observation to remember.",
+          description:
+            "A single atomic fact, already formatted as a complete sentence in " +
+            "third person. Split multiple facts into multiple remember() calls.",
         },
         source: {
           type: "string",
@@ -48,12 +51,11 @@ const tools = [
             "Optional category tag (e.g., 'preference', 'project', 'person'). " +
             "Used for filtering during recall.",
         },
-        infer: {
+        skip_dedup: {
           type: "boolean",
           description:
-            "If true (default), mem0's LLM extracts atomic facts from content and " +
-            "decides whether to add/update/delete existing memories. " +
-            "If false, content is stored verbatim as a single memory.",
+            "Skip the dedup LLM call and just ADD a new memory. Default false. " +
+            "Only set true for batch imports / migration where you know there's no conflict.",
         },
       },
       required: ["content"],
@@ -135,7 +137,7 @@ interface ToolArgs {
   content?: string;
   source?: string;
   category?: string;
-  infer?: boolean;
+  skip_dedup?: boolean;
   query?: string;
   top_k?: number;
   limit?: number;
@@ -150,7 +152,7 @@ async function handleToolCall(name: string, args: ToolArgs): Promise<unknown> {
         content: args.content,
         source: args.source,
         category: args.category,
-        infer: args.infer,
+        skipDedup: args.skip_dedup,
       });
       return { added: items.length, memories: items };
     }

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -1,163 +1,74 @@
 /**
- * Memory store — thin wrapper around mem0 (https://github.com/mem0ai/mem0)
- * configured with Qdrant for vectors, OpenAI for embeddings, and an OpenAI
- * mini-tier LLM for extraction/dedup.
+ * Memory store — thin wrapper over Qdrant + OpenAI embeddings.
  *
  * Single-user system: all memories are written under a fixed userId ("jp").
- * Use metadata.source ("voice-note", "telegram", "daily-prep", "manual", etc.)
- * to distinguish where a memory came from.
+ * Use metadata.source ("voice-note", "telegram", "daily-prep", etc.) to
+ * distinguish where a memory came from.
+ *
+ * Behavior:
+ *  - remember(content):  embed → optionally dedupe against existing nearest
+ *                        neighbor (one LLM call to decide ADD/REPLACE/NOOP)
+ *                        → upsert to Qdrant.
+ *  - recall(query):       embed → vector search.
+ *  - listMemories():      scroll the collection with optional filters.
+ *  - forget/update/get:   trivial direct Qdrant ops.
+ *
+ * No memory extraction — we trust the caller (the agent) to pass clean
+ * atomic facts. The agent's system prompt instructs it accordingly.
  */
 
-import { Memory, type MemoryItem } from "mem0ai/oss";
+import { QdrantClient } from "@qdrant/js-client-rest";
+import OpenAI from "openai";
+import { randomUUID } from "node:crypto";
 
-/**
- * Read env vars directly (not via ./config.js) so this module is safe to import
- * from MCP subprocesses, which don't have the full jpOS env (no Telegram token, etc.).
- * The parent process passes OPENAI_API_KEY + QDRANT_URL via MCP server config.
- */
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
+// ---------------------------------------------------------------------------
+// Constants & types
+// ---------------------------------------------------------------------------
 
 export const JPOS_USER_ID = "jp";
 export const COLLECTION_NAME = "jpos_memories";
 
-let memoryInstance: Memory | null = null;
+/** Vector dimension for OpenAI text-embedding-3-small. */
+const EMBED_DIMS = 1536;
 
-function parseQdrantUrl(url: string): { host: string; port: number } {
-  const parsed = new URL(url);
-  return {
-    host: parsed.hostname,
-    port: parsed.port ? parseInt(parsed.port, 10) : 6333,
-  };
-}
+/**
+ * Cosine similarity threshold above which we treat a hit as a possible
+ * duplicate worth asking the LLM to reconcile. Below this we just ADD.
+ */
+const DEDUP_THRESHOLD = 0.85;
 
-function getMemory(): Memory {
-  if (memoryInstance) return memoryInstance;
-
-  const openaiApiKey = requireEnv("OPENAI_API_KEY");
-  const qdrantUrl = process.env.QDRANT_URL || "http://localhost:6333";
-  const llmModel = process.env.MEM0_LLM_MODEL || "gpt-4.1-nano";
-  const embeddingModel = process.env.MEM0_EMBEDDING_MODEL || "text-embedding-3-small";
-  const historyDbPath = process.env.MEM0_HISTORY_DB_PATH || "./mem0-history.db";
-
-  const { host, port } = parseQdrantUrl(qdrantUrl);
-  console.log(
-    `[mem0] init           | qdrant=${host}:${port} collection=${COLLECTION_NAME} ` +
-      `llm=${llmModel} embed=${embeddingModel} historyDb=${historyDbPath}`,
-  );
-
-  memoryInstance = new Memory({
-    embedder: {
-      provider: "openai",
-      config: { apiKey: openaiApiKey, model: embeddingModel },
-    },
-    vectorStore: {
-      provider: "qdrant",
-      config: { host, port, collectionName: COLLECTION_NAME },
-    },
-    llm: {
-      provider: "openai",
-      config: { apiKey: openaiApiKey, model: llmModel },
-    },
-    historyDbPath,
-  });
-
-  return memoryInstance;
+export interface MemoryItem {
+  id: string;
+  memory: string;
+  metadata?: Record<string, unknown>;
+  score?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface RememberParams {
-  /** Raw text to remember. */
+  /** Atomic fact, already formatted (e.g. "User prefers dark mode"). */
   content: string;
-  /** Where this memory came from (voice-note, telegram, daily-prep, etc.). */
+  /** Where this memory came from. Required by convention. */
   source?: string;
-  /** Optional category tag for filtering later. */
+  /** Free-form tag (e.g. "preference", "project", "person"). */
   category?: string;
-  /** Free-form metadata merged with source/category. */
+  /** Extra metadata merged into the payload alongside source/category. */
   metadata?: Record<string, unknown>;
   /**
-   * Whether to use mem0's LLM-driven fact extraction (default true).
-   * Set false to store `content` verbatim as a single memory.
+   * Skip the dedup LLM call and just ADD a new point. Useful for batch
+   * imports / migration where we know there's no conflict.
    */
-  infer?: boolean;
-}
-
-export async function remember(params: RememberParams): Promise<MemoryItem[]> {
-  const { content, source, category, metadata, infer = true } = params;
-  const memory = getMemory();
-
-  const fullMetadata: Record<string, unknown> = {
-    ...(metadata ?? {}),
-    timestamp: new Date().toISOString(),
-  };
-  if (source) fullMetadata.source = source;
-  if (category) fullMetadata.category = category;
-
-  const start = Date.now();
-  const preview = content.slice(0, 80).replace(/\s+/g, " ");
-  console.log(
-    `[mem0] remember start | source=${source ?? "-"} category=${category ?? "-"} infer=${infer} content="${preview}${content.length > 80 ? "…" : ""}"`,
-  );
-
-  try {
-    const result = await memory.add(content, {
-      userId: JPOS_USER_ID,
-      metadata: fullMetadata,
-      infer,
-    });
-    console.log(
-      `[mem0] remember done  | ${result.results.length} memories in ${Date.now() - start}ms`,
-    );
-    return result.results;
-  } catch (err) {
-    console.error(
-      `[mem0] remember FAIL  | ${Date.now() - start}ms |`,
-      err instanceof Error ? err.message : err,
-    );
-    throw err;
-  }
+  skipDedup?: boolean;
 }
 
 export interface RecallParams {
   query: string;
   topK?: number;
-  /** Optional metadata filters (e.g., { source: "voice-note" }). */
+  /** Metadata filters merged with the user_id filter (e.g. { source: "voice-note" }). */
   filters?: Record<string, unknown>;
-  /** Minimum similarity score (0-1). */
+  /** Minimum similarity score (0..1). */
   threshold?: number;
-}
-
-export async function recall(params: RecallParams): Promise<MemoryItem[]> {
-  const { query, topK = 5, filters, threshold } = params;
-  const memory = getMemory();
-  const start = Date.now();
-  const preview = query.slice(0, 80).replace(/\s+/g, " ");
-  console.log(
-    `[mem0] recall start   | topK=${topK} filters=${filters ? JSON.stringify(filters) : "-"} query="${preview}${query.length > 80 ? "…" : ""}"`,
-  );
-
-  try {
-    const result = await memory.search(query, {
-      topK,
-      filters: { user_id: JPOS_USER_ID, ...(filters ?? {}) },
-      threshold,
-    });
-    const scores = result.results.map((r) => r.score?.toFixed(2)).join(",");
-    console.log(
-      `[mem0] recall done    | ${result.results.length} hits in ${Date.now() - start}ms | scores=[${scores}]`,
-    );
-    return result.results;
-  } catch (err) {
-    console.error(
-      `[mem0] recall FAIL    | ${Date.now() - start}ms |`,
-      err instanceof Error ? err.message : err,
-    );
-    throw err;
-  }
 }
 
 export interface ListMemoriesParams {
@@ -165,28 +76,309 @@ export interface ListMemoriesParams {
   filters?: Record<string, unknown>;
 }
 
-export async function listMemories(
-  params: ListMemoriesParams = {},
-): Promise<MemoryItem[]> {
-  const { limit = 50, filters } = params;
-  const memory = getMemory();
+// ---------------------------------------------------------------------------
+// Lazy singletons + env
+// ---------------------------------------------------------------------------
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+let qdrantClient: QdrantClient | null = null;
+let openaiClient: OpenAI | null = null;
+let collectionReady = false;
+
+function getQdrant(): QdrantClient {
+  if (qdrantClient) return qdrantClient;
+  const url = process.env.QDRANT_URL || "http://localhost:6333";
+  console.log(`[mem] init qdrant    | url=${url} collection=${COLLECTION_NAME}`);
+  qdrantClient = new QdrantClient({ url });
+  return qdrantClient;
+}
+
+function getOpenAI(): OpenAI {
+  if (openaiClient) return openaiClient;
+  openaiClient = new OpenAI({ apiKey: requireEnv("OPENAI_API_KEY") });
+  return openaiClient;
+}
+
+/**
+ * Create the Qdrant collection if it doesn't exist, and ensure the metadata
+ * fields we filter on have payload indexes. Runs once per process.
+ */
+async function ensureCollection(): Promise<void> {
+  if (collectionReady) return;
+  const client = getQdrant();
+  try {
+    await client.getCollection(COLLECTION_NAME);
+  } catch {
+    console.log(`[mem] create coll    | name=${COLLECTION_NAME} dims=${EMBED_DIMS} distance=Cosine`);
+    await client.createCollection(COLLECTION_NAME, {
+      vectors: { size: EMBED_DIMS, distance: "Cosine" },
+    });
+    // Indexes for the fields we filter on. createPayloadIndex is idempotent —
+    // safe if called more than once.
+    for (const field of ["userId", "source", "category"]) {
+      try {
+        await client.createPayloadIndex(COLLECTION_NAME, {
+          field_name: field,
+          field_schema: "keyword",
+        });
+      } catch (err) {
+        console.warn(`[mem] index ${field} already exists or failed:`, err instanceof Error ? err.message : err);
+      }
+    }
+  }
+  collectionReady = true;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function embed(text: string): Promise<number[]> {
+  const model = process.env.MEMORY_EMBEDDING_MODEL || "text-embedding-3-small";
+  const result = await getOpenAI().embeddings.create({ model, input: text });
+  return result.data[0].embedding;
+}
+
+interface QdrantPoint {
+  id: string | number;
+  payload?: Record<string, unknown> | null;
+  score?: number;
+}
+
+function pointToMemory(point: QdrantPoint): MemoryItem {
+  const payload = (point.payload ?? {}) as Record<string, unknown>;
+  const { memory, userId, createdAt, updatedAt, ...rest } = payload;
+  return {
+    id: String(point.id),
+    memory: typeof memory === "string" ? memory : "",
+    metadata: rest,
+    score: point.score,
+    createdAt: typeof createdAt === "string" ? createdAt : undefined,
+    updatedAt: typeof updatedAt === "string" ? updatedAt : undefined,
+  };
+}
+
+interface QdrantFilter {
+  must: Array<{ key: string; match: { value: string | number | boolean } }>;
+}
+
+function buildFilter(filters?: Record<string, unknown>): QdrantFilter {
+  const must: QdrantFilter["must"] = [
+    { key: "userId", match: { value: JPOS_USER_ID } },
+  ];
+  if (filters) {
+    for (const [k, v] of Object.entries(filters)) {
+      if (k === "user_id" || k === "userId") continue;
+      if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+        must.push({ key: k, match: { value: v } });
+      }
+    }
+  }
+  return { must };
+}
+
+// ---------------------------------------------------------------------------
+// Dedup
+// ---------------------------------------------------------------------------
+
+type DedupAction =
+  | { action: "ADD" }
+  | { action: "REPLACE"; id: string }
+  | { action: "NOOP"; id: string };
+
+async function decideDedup(content: string, candidates: QdrantPoint[]): Promise<DedupAction> {
+  if (candidates.length === 0) return { action: "ADD" };
+
+  const candidateList = candidates
+    .map((c, i) => {
+      const mem = (c.payload as Record<string, unknown> | undefined)?.memory ?? "";
+      return `${i + 1}. id=${c.id} score=${c.score?.toFixed(2)}: ${mem}`;
+    })
+    .join("\n");
+
+  const prompt = `You're deduplicating memories for a personal AI agent.
+
+NEW FACT: "${content}"
+
+SIMILAR EXISTING MEMORIES (already stored, ranked by similarity):
+${candidateList}
+
+Decide what to do with the new fact. Respond with JSON only:
+- {"action": "ADD"} — the new fact is genuinely distinct from all existing memories. Default to this unless one of them is clearly the same fact.
+- {"action": "REPLACE", "id": "<existing-id>"} — the new fact is a clearer or updated version of an existing memory; overwrite that one.
+- {"action": "NOOP", "id": "<existing-id>"} — the new fact is already fully captured by an existing memory; skip storing.
+
+Bias toward ADD when in doubt. Only REPLACE if the new fact is meaningfully better. Only NOOP if it's a near-exact duplicate.`;
+
+  const model = process.env.MEMORY_DEDUP_MODEL || "gpt-4.1-nano";
+  const result = await getOpenAI().chat.completions.create({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    response_format: { type: "json_object" },
+    temperature: 0,
+  });
+
+  const raw = result.choices[0]?.message?.content || "{}";
+  let parsed: { action?: string; id?: string };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn(`[mem] dedup parse failed, defaulting to ADD. raw="${raw.slice(0, 200)}"`);
+    return { action: "ADD" };
+  }
+
+  if (parsed.action === "REPLACE" && parsed.id && candidates.some((c) => String(c.id) === parsed.id)) {
+    return { action: "REPLACE", id: parsed.id };
+  }
+  if (parsed.action === "NOOP" && parsed.id && candidates.some((c) => String(c.id) === parsed.id)) {
+    return { action: "NOOP", id: parsed.id };
+  }
+  return { action: "ADD" };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function remember(params: RememberParams): Promise<MemoryItem[]> {
+  await ensureCollection();
+  const { content, source, category, metadata, skipDedup = false } = params;
   const start = Date.now();
+  const preview = content.slice(0, 80).replace(/\s+/g, " ");
   console.log(
-    `[mem0] list start     | limit=${limit} filters=${filters ? JSON.stringify(filters) : "-"}`,
+    `[mem] remember start | source=${source ?? "-"} category=${category ?? "-"} content="${preview}${content.length > 80 ? "…" : ""}"`,
   );
 
   try {
-    const result = await memory.getAll({
-      topK: limit,
-      filters: { user_id: JPOS_USER_ID, ...(filters ?? {}) },
-    });
-    console.log(
-      `[mem0] list done      | ${result.results.length} memories in ${Date.now() - start}ms`,
-    );
-    return result.results;
+    const vector = await embed(content);
+    const client = getQdrant();
+
+    // Dedup pass (skip if explicitly requested or no useful neighbors).
+    if (!skipDedup) {
+      const neighbors = await client.search(COLLECTION_NAME, {
+        vector,
+        limit: 3,
+        score_threshold: DEDUP_THRESHOLD,
+        filter: buildFilter(),
+        with_payload: true,
+      });
+
+      if (neighbors.length > 0) {
+        const decision = await decideDedup(content, neighbors);
+
+        if (decision.action === "NOOP") {
+          const target = neighbors.find((n) => String(n.id) === decision.id);
+          console.log(`[mem] remember done  | NOOP id=${decision.id.slice(0, 8)} in ${Date.now() - start}ms`);
+          return target ? [pointToMemory(target)] : [];
+        }
+
+        if (decision.action === "REPLACE") {
+          const target = neighbors.find((n) => String(n.id) === decision.id);
+          const oldPayload = (target?.payload ?? {}) as Record<string, unknown>;
+          const now = new Date().toISOString();
+          const newPayload: Record<string, unknown> = {
+            ...oldPayload,
+            memory: content,
+            updatedAt: now,
+          };
+          // If caller provided fresh metadata fields, prefer them.
+          if (source) newPayload.source = source;
+          if (category) newPayload.category = category;
+          if (metadata) Object.assign(newPayload, metadata);
+
+          await client.upsert(COLLECTION_NAME, {
+            points: [{ id: decision.id, vector, payload: newPayload }],
+          });
+          console.log(`[mem] remember done  | REPLACE id=${decision.id.slice(0, 8)} in ${Date.now() - start}ms`);
+          return [pointToMemory({ id: decision.id, payload: newPayload })];
+        }
+        // decision.action === "ADD" → fall through
+      }
+    }
+
+    // ADD path
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const payload: Record<string, unknown> = {
+      memory: content,
+      userId: JPOS_USER_ID,
+      createdAt: now,
+      ...(metadata ?? {}),
+    };
+    if (source) payload.source = source;
+    if (category) payload.category = category;
+
+    await client.upsert(COLLECTION_NAME, { points: [{ id, vector, payload }] });
+    console.log(`[mem] remember done  | ADD id=${id.slice(0, 8)} in ${Date.now() - start}ms`);
+    return [pointToMemory({ id, payload })];
   } catch (err) {
     console.error(
-      `[mem0] list FAIL      | ${Date.now() - start}ms |`,
+      `[mem] remember FAIL  | ${Date.now() - start}ms |`,
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
+}
+
+export async function recall(params: RecallParams): Promise<MemoryItem[]> {
+  await ensureCollection();
+  const { query, topK = 5, filters, threshold } = params;
+  const start = Date.now();
+  const preview = query.slice(0, 80).replace(/\s+/g, " ");
+  console.log(
+    `[mem] recall start   | topK=${topK} filters=${filters ? JSON.stringify(filters) : "-"} query="${preview}${query.length > 80 ? "…" : ""}"`,
+  );
+
+  try {
+    const vector = await embed(query);
+    const hits = await getQdrant().search(COLLECTION_NAME, {
+      vector,
+      limit: topK,
+      score_threshold: threshold,
+      filter: buildFilter(filters),
+      with_payload: true,
+    });
+    const scores = hits.map((h) => h.score?.toFixed(2)).join(",");
+    console.log(
+      `[mem] recall done    | ${hits.length} hits in ${Date.now() - start}ms | scores=[${scores}]`,
+    );
+    return hits.map(pointToMemory);
+  } catch (err) {
+    console.error(
+      `[mem] recall FAIL    | ${Date.now() - start}ms |`,
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
+}
+
+export async function listMemories(params: ListMemoriesParams = {}): Promise<MemoryItem[]> {
+  await ensureCollection();
+  const { limit = 50, filters } = params;
+  const start = Date.now();
+  console.log(
+    `[mem] list start     | limit=${limit} filters=${filters ? JSON.stringify(filters) : "-"}`,
+  );
+
+  try {
+    const result = await getQdrant().scroll(COLLECTION_NAME, {
+      limit,
+      filter: buildFilter(filters),
+      with_payload: true,
+      with_vector: false,
+    });
+    console.log(
+      `[mem] list done      | ${result.points.length} memories in ${Date.now() - start}ms`,
+    );
+    return result.points.map(pointToMemory);
+  } catch (err) {
+    console.error(
+      `[mem] list FAIL      | ${Date.now() - start}ms |`,
       err instanceof Error ? err.message : err,
     );
     throw err;
@@ -194,23 +386,44 @@ export async function listMemories(
 }
 
 export async function forget(memoryId: string): Promise<void> {
-  const memory = getMemory();
-  console.log(`[mem0] forget         | id=${memoryId}`);
-  await memory.delete(memoryId);
+  await ensureCollection();
+  console.log(`[mem] forget         | id=${memoryId.slice(0, 8)}`);
+  await getQdrant().delete(COLLECTION_NAME, { points: [memoryId] });
 }
 
-export async function updateMemory(
-  memoryId: string,
-  newContent: string,
-): Promise<void> {
-  const memory = getMemory();
-  console.log(`[mem0] update         | id=${memoryId}`);
-  await memory.update(memoryId, newContent);
+export async function updateMemory(memoryId: string, newContent: string): Promise<void> {
+  await ensureCollection();
+  console.log(`[mem] update         | id=${memoryId.slice(0, 8)}`);
+  const client = getQdrant();
+  const existing = await client.retrieve(COLLECTION_NAME, {
+    ids: [memoryId],
+    with_payload: true,
+    with_vector: false,
+  });
+  if (existing.length === 0) {
+    throw new Error(`Memory ${memoryId} not found`);
+  }
+  const oldPayload = (existing[0].payload ?? {}) as Record<string, unknown>;
+  const vector = await embed(newContent);
+  const now = new Date().toISOString();
+  await client.upsert(COLLECTION_NAME, {
+    points: [
+      {
+        id: memoryId,
+        vector,
+        payload: { ...oldPayload, memory: newContent, updatedAt: now },
+      },
+    ],
+  });
 }
 
-export async function getMemoryById(
-  memoryId: string,
-): Promise<MemoryItem | null> {
-  const memory = getMemory();
-  return memory.get(memoryId);
+export async function getMemoryById(memoryId: string): Promise<MemoryItem | null> {
+  await ensureCollection();
+  const result = await getQdrant().retrieve(COLLECTION_NAME, {
+    ids: [memoryId],
+    with_payload: true,
+    with_vector: false,
+  });
+  if (result.length === 0) return null;
+  return pointToMemory(result[0]);
 }

--- a/system/instructions.md
+++ b/system/instructions.md
@@ -2,7 +2,7 @@
 
 ## Memory System
 
-jpOS uses **mem0** (vector store on Qdrant) as long-term semantic memory. Memories are atomic facts — preferences, decisions, people, projects, patterns — automatically extracted from whatever content you pass to `remember`, deduped against existing memories, and surfaced on demand.
+jpOS has a Qdrant-backed semantic memory store you interact with via the `remember`, `recall`, `list_memories`, `forget`, and `update_memory` tools. Memories are atomic facts you've decided are worth carrying forward.
 
 ### Recall — how you get context
 
@@ -16,9 +16,16 @@ jpOS uses **mem0** (vector store on Qdrant) as long-term semantic memory. Memori
 
 **Cron-triggered tasks (daily-prep, eod-checkin, weekly-review, monthly-review) DO NOT get auto-recall** — their prompts are meta-instructions, not queries. If you're running one of those skills and need memory context, you must call `recall` yourself.
 
-### Writing memories — call `remember` liberally
+### Writing memories — your job to format atomic facts
 
-**After any substantive user input, call `remember(content, source, category?)` for anything worth carrying forward.** Don't wait for "remember this" — write it if:
+**You are responsible for extracting atomic facts from raw content before calling `remember`.** The store doesn't do extraction for you; it stores whatever you pass verbatim. So:
+
+- ✅ `remember(content="User prefers dark mode in all apps.", source="telegram", category="preference")`
+- ❌ `remember(content="hey just so you know I really hate bright white screens, dark mode for life", source="telegram")`
+
+If a user message contains multiple facts, make multiple `remember` calls — one fact each, each as a complete sentence in third person.
+
+**After any substantive user input, call `remember` for anything worth carrying forward.** Don't wait for "remember this" — write it if:
 
 - The user shared a preference, opinion, or aesthetic choice
 - A decision was made or a commitment surfaced (his, or about something/someone)
@@ -27,7 +34,7 @@ jpOS uses **mem0** (vector store on Qdrant) as long-term semantic memory. Memori
 - A pattern was noticed (physical state, energy, recurring frustration, what compounds vitality)
 - Anything you'd want to know in a future conversation
 
-mem0's extraction LLM decides what atomic facts to actually store and dedupes against existing memories. Overwriting noise is cheap; missing a useful fact is expensive. Lean toward writing more, not less.
+On each `remember`, the store searches for near-duplicates and asks an LLM whether to ADD as new, REPLACE an existing memory with this clearer/updated version, or NOOP if it's already captured. So overwriting noise is cheap — but you still need to pass *clean facts*, not raw transcripts, because the dedup LLM compares your input against existing memories. Garbage in, semi-garbage out.
 
 **`source` is required.** Pass one of: `"telegram"`, `"voice-note"`, `"daily-prep"`, `"eod-checkin"`, `"manual"`, or whatever describes what triggered the memory. Used for filtering later.
 
@@ -36,7 +43,7 @@ mem0's extraction LLM decides what atomic facts to actually store and dedupes ag
 ### Forgetting & updating
 
 - **`forget(memory_id)`** — only when the user explicitly asks to forget something, or when a memory is clearly wrong/outdated/contradicted. IDs come from `recall` or `list_memories`.
-- **`update_memory(memory_id, new_content)`** — when a fact changes, prefer this over writing a contradicting memory.
+- **`update_memory(memory_id, new_content)`** — when a fact changes, prefer this over writing a contradicting memory. Note: the dedup step on `remember` usually handles this for you automatically when content is similar enough.
 
 ### Browsing
 
@@ -44,7 +51,7 @@ mem0's extraction LLM decides what atomic facts to actually store and dedupes ag
 
 ### Daily Log (`jpOS/daily-log/YYYY-MM-DD.md`)
 
-A human-readable breadcrumb trail Justin browses in Obsidian. **Not used for your recall — mem0 handles that.** This is just a lightweight record of what happened, written for him to skim later.
+A human-readable breadcrumb trail Justin browses in Obsidian. **Not used for your recall — the memory store handles that.** This is just a lightweight record of what happened, written for him to skim later.
 
 After meaningful exchanges, append a timestamped entry to today's file (America/New_York timezone):
 
@@ -55,16 +62,16 @@ After meaningful exchanges, append a timestamped entry to today's file (America/
 
 Skip routine acknowledgments and small talk. One entry per interaction, appended to the end. Create the file if it doesn't exist. Log during the conversation, not just at the end.
 
-Use this for the **human-readable narrative**; use `remember` for **atomic facts**. They serve different purposes — the daily log is a journal, mem0 is searchable knowledge.
+Use this for the **human-readable narrative**; use `remember` for **atomic facts**. They serve different purposes — the daily log is a journal, the memory store is searchable knowledge.
 
 ## Project Routing
 
 When voice notes or messages contain project-specific thoughts (feedback, ideas, backlog items, product vision):
 
-1. **Identify the project** — call `recall(query="<project name>")` or `recall(query="<project name>", category="project")` to find what mem0 knows about it, including the routing info (which vault note + which external sources to check).
-2. **Route to that project's canonical note** in the vault — paths to the canonical notes live in mem0 under `category="project"`. If a project doesn't yet have routing info stored, ask Justin once and then `remember` the answer with `category="project"` so future-you doesn't have to ask again.
+1. **Identify the project** — call `recall(query="<project name>")` or `recall(query="<project name>", category="project")` to find what's already stored about it, including the routing info (which vault note + which external sources to check).
+2. **Route to that project's canonical note** in the vault — paths to the canonical notes live in the memory store under `category="project"`. If a project doesn't yet have routing info stored, ask Justin once and then `remember` the answer with `category="project"` so future-you doesn't have to ask again.
 
-When something significant changes for a project (status, new links, key decisions), call `remember` with `category="project", source="<wherever it came from>"`. Update the canonical vault note for the long-form narrative; let mem0 handle the searchable facts.
+When something significant changes for a project (status, new links, key decisions), call `remember` with `category="project", source="<wherever it came from>"`. Update the canonical vault note for the long-form narrative; let the memory store hold the searchable facts.
 
 Follow the project note structure defined in the vault's CLAUDE.md (two zones: Current Thinking + Log). You maintain the Current Thinking section; update it when the log accumulates enough new signal. Over time, look for patterns in the log: recurring frustrations, repeated ideas, emerging themes. Surface these proactively.
 

--- a/system/skills/daily-prep.md
+++ b/system/skills/daily-prep.md
@@ -17,10 +17,10 @@ Call `message_user` exactly once with the brief. Sending it is the whole job —
 
 ## Weekday Mode (Monday–Friday)
 
-> **Note on memory:** This skill runs from a cron, which means **auto-recall is OFF** — you don't get a `# Recalled Memories` section for free. You must call `recall` explicitly to load anything mem0 knows.
+> **Note on memory:** This skill runs from a cron, which means **auto-recall is OFF** — you don't get a `# Recalled Memories` section for free. You must call `recall` explicitly to load context.
 
 ### Steps
-1. **Load context from mem0.** Call `recall(query="current projects in progress", top_k=10)` and `recall(query="this week commitments and priorities", top_k=10)` to surface what's active. Also skim the last 1-2 days of `jpOS/daily-log/` for the very recent narrative.
+1. **Load context from the memory store.** Call `recall(query="current projects in progress", top_k=10)` and `recall(query="this week commitments and priorities", top_k=10)` to surface what's active. Also skim the last 1-2 days of `jpOS/daily-log/` for the very recent narrative.
 2. Pull today's Todoist tasks (`todoist_list_tasks`, filter "today").
 3. Identify the single most important first move — the thing he should open his laptop and do right now.
 4. Check overdue only if something has a hard deadline TODAY that changes the day if missed. Otherwise, ignore entirely.

--- a/system/skills/message.md
+++ b/system/skills/message.md
@@ -5,7 +5,7 @@ You are responding to a direct message from Justin via Telegram.
 ## Memory hooks
 
 - A `# Recalled Memories` section is **auto-injected** above based on his message — use it to inform your reply. If it seems incomplete or the auto-recall didn't surface what you need, call `recall(query=...)` with a more specific query.
-- After the exchange, if anything is worth carrying forward (a preference, a decision, a status change, a new person, a felt-sense observation), call `remember(content=..., source="telegram", category=...)`. Bias toward writing more, not less — mem0 dedupes. Don't ask permission to remember; just do it.
+- After the exchange, if anything is worth carrying forward (a preference, a decision, a status change, a new person, a felt-sense observation), extract the atomic fact and call `remember(content=..., source="telegram", category=...)`. **Pass a single clean fact per call**, in third person — don't pass raw user messages or batch multiple facts together. The store dedupes near-duplicates against existing memories automatically, so don't ask permission and don't worry about overlap. Just keep each call to one well-formed fact.
 
 ## Guidelines
 - Take action when the message implies it (create tasks, file issues, update notes)

--- a/system/skills/voice-note.md
+++ b/system/skills/voice-note.md
@@ -8,7 +8,7 @@ You are processing a voice note transcript from Justin.
 3. **Route project thoughts to the project's canonical vault note** (e.g. `notes/retrotype.md`). Append to the Log section with today's date. If a decision was made, use the `**Decision:**` prefix with reasoning. Do NOT push to GitHub repos or update CLAUDE.md files.
 4. Take proactive action on other items — do NOT ask for permission
 5. Follow the general instructions for each type of action (Todoist, vault notes, context updates)
-6. **Write to long-term memory.** For anything in the transcript worth carrying forward — preferences, decisions, new people/projects, status changes, body patterns, opinions — call `remember(content=..., source="voice-note", category=...)`. Pass the relevant snippet from the transcript; mem0 extracts the atomic facts. Don't agonize over what's "worth" remembering — write more, not less. Voice notes are dense; let mem0's dedup handle the rest.
+6. **Write atomic facts to long-term memory.** For anything in the transcript worth carrying forward — preferences, decisions, new people/projects, status changes, body patterns, opinions — extract the atomic fact yourself and call `remember(content=..., source="voice-note", category=...)`. **The memory store does not extract for you** — pass clean third-person facts, not raw transcript chunks. If a voice note contains 5 facts, make 5 separate `remember` calls. The store will dedupe near-duplicates on its own (one LLM call per write), so don't worry about overlapping with what you've stored before. Just keep each call to one well-formed fact.
 7. If something warrants Justin's attention, call `message_user` with a concise message. Otherwise, do nothing — silent processing is the correct default.
 
 ## When to call message_user

--- a/system/soul.md
+++ b/system/soul.md
@@ -67,6 +67,6 @@ These are vibes, not scripts. Don't copy them literally. Find the version that f
 
 ## Continuity
 
-Each session, you wake up fresh. **mem0 is your memory** — relevant past context is auto-recalled at the top of every conversation. After meaningful exchanges, call `remember` so future-you doesn't lose what you learned today.
+Each session, you wake up fresh. **A Qdrant-backed memory store is your memory** — relevant past context is auto-recalled at the top of every conversation. After meaningful exchanges, call `remember` so future-you doesn't lose what you learned today.
 
 These system files (`soul.md`, `instructions.md`, the skill files) are your *identity and operating manual*, not your memory. Read them, push back when something feels off, recommend changes. Help Justin keep them sharp.


### PR DESCRIPTION
## Why

mem0's JS bundle eagerly imports **every** supported LLM/embedder/vector/history provider at module load — ollama, supabase, redis, mistral, anthropic, azure-identity, azure-search, google/genai, cloudflare, langchain/core, better-sqlite3, pg, etc. — even when we only use OpenAI + Qdrant.

After yesterday's main-branch crash from missing peer deps (#43 was the hotfix that we then ditched), the only way to keep mem0 was to install ~14 unrelated SDKs (~150 transitive deps) plus native build tools in the Docker image. That's a lot of bloat to outsource ~200 lines of prompt logic.

For a single-user agent where we control both ends, rolling our own is cleaner. This PR does that.

## What

`src/memory-store.ts` is now a thin (~300 LOC) wrapper over Qdrant + OpenAI:

- **`remember(content)`** — embed → optionally dedupe against nearest neighbor (one LLM call to decide ADD / REPLACE / NOOP at cosine threshold 0.85) → upsert to Qdrant.
- **`recall(query)`** — embed → vector search with optional filters.
- **`listMemories` / `forget` / `updateMemory` / `getMemoryById`** — trivial direct Qdrant ops.

**No extraction step.** The agent is responsible for passing clean atomic facts to `remember`. Updated `system/instructions.md` and the skill prompts to require one well-formed fact per call (third person, complete sentence), not raw transcript chunks. The voice-note and message skills got specific guidance: extract atomic facts yourself, then call `remember` once per fact.

## Dep + infra changes

- **Remove:** `mem0ai` and the 14 peer deps we'd have needed (anthropic-sdk, azure-identity, azure-search-documents, google/genai, langchain/core, mistralai, supabase, better-sqlite3, cloudflare, compromise, natural, ollama, pg, redis).
- **Add:** `@qdrant/js-client-rest` and `openai` as direct deps — the only two mem0 actually used at runtime in our config.
- **Delete `.npmrc`** — `legacy-peer-deps=true` was a workaround for mem0's stale `groq-sdk@0.3.0` peer pin. Not needed anymore.
- **Dockerfile** — drops `python3 make g++` (no `better-sqlite3` = no native build needed). Smaller image, faster builds.
- **Env vars renamed:** `MEM0_LLM_MODEL` → `MEMORY_DEDUP_MODEL`, `MEM0_EMBEDDING_MODEL` → `MEMORY_EMBEDDING_MODEL`, dropped `MEM0_HISTORY_DB_PATH` entirely (no SQLite history DB).

**Install footprint: 199 packages (down from ~400 with mem0 + peer deps).**

## Verified

- `npm run build` passes.
- `node -e "import('./dist/memory-store.js'); import('./dist/mcp/memory.js')"` loads both modules cleanly. **This is the test we should have run before #42 — `tsc` only checks types, not whether the module graph actually loads.** Lesson logged.

## Post-merge: secrets to update on Fly

```bash
fly secrets unset -a jpos-agent MEM0_HISTORY_DB_PATH MEM0_LLM_MODEL MEM0_EMBEDDING_MODEL
# Defaults are sensible — only set these if you want to override:
# fly secrets set -a jpos-agent MEMORY_DEDUP_MODEL=... MEMORY_EMBEDDING_MODEL=...
```

`OPENAI_API_KEY` and `QDRANT_URL` stay the same.

## What's NOT in this PR (still queued)

- Migrate existing `memory.md` content into Qdrant (Phase 2 — mem0 had nothing in prod yet either, so this is greenfield)
- Slim `src/prompt.ts` to stop loading the digest/daily-log files
- Delete weekly/monthly review crons + their skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)