### PR TITLE
Bind Qdrant to :: so jpos-agent can actually reach it

### DIFF
--- a/jpos-qdrant/fly.toml
+++ b/jpos-qdrant/fly.toml
@@ -19,7 +19,9 @@ primary_region = "ord"
   image = "qdrant/qdrant:latest"
 
 [env]
-  # Bind Qdrant on all interfaces so .internal DNS reaches it.
+  # Bind to all interfaces, dual-stack. The default ("0.0.0.0") is IPv4-only,
+  # which means traffic over Fly's .internal DNS (IPv6) gets refused.
+  QDRANT__SERVICE__HOST = "::"
   QDRANT__SERVICE__HTTP_PORT = "6333"
   QDRANT__SERVICE__GRPC_PORT = "6334"
   # Keep telemetry off for a personal-data store.


### PR DESCRIPTION
## Why

jpos-agent's first interaction with the new Qdrant memory store failed with `[agent] auto-recall failed: fetch failed`. Diagnosis:

```bash
$ fly ssh console -a jpos-agent -C "getent hosts jpos-qdrant.internal; curl -v http://jpos-qdrant.internal:6333/collections"
fdaa:30:3bea:a7b:855:af42:dc8b:2 jpos-qdrant.internal     # DNS fine
* Trying [fdaa:30:3bea:a7b:855:af42:dc8b:2]:6333...
* connect to ... port 6333 failed: Connection refused      # Qdrant not listening on IPv6
```

Qdrant's startup logs confirmed it was binding to `0.0.0.0:6333` — IPv4 only. Fly's `.internal` DNS resolves to IPv6, so traffic hit the machine but no socket was listening. Fly's TCP health check passed because it was probing the internal 0.0.0.0 binding via the machine's own loopback.

## Fix

Set `QDRANT__SERVICE__HOST = "::"` in `jpos-qdrant/fly.toml`. Linux's default dual-stack behavior means binding to `::` covers IPv4 too via v4-mapped-in-v6, so we don't need to bind both.

## Verified post-deploy

```bash
$ fly ssh console -a jpos-agent -C "curl -m 5 http://jpos-qdrant.internal:6333/collections"
{"result":{"collections":[]},"status":"ok","time":0.00053702}
```

This was already deployed manually with `fly deploy` from the worktree before opening the PR. CI on main will redeploy on merge but the live state matches the committed config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)