### PR TITLE
Tighten remember() guidance to prevent multi-entity bundling

### DIFF
--- a/src/mcp/memory.ts
+++ b/src/mcp/memory.ts
@@ -25,19 +25,27 @@ const tools = [
   {
     name: "remember",
     description:
-      "Store an atomic fact to long-term memory. Pass a single well-formed fact " +
-      "in third person (e.g. \"User prefers dark mode\"), not raw conversation text " +
-      "or multiple facts in one call. On write, the store searches for near-duplicates " +
-      "and asks an LLM whether to ADD (default), REPLACE an existing memory with this " +
-      "clearer/updated version, or NOOP if it's already captured.",
+      "Store ONE fact to long-term memory. Always third person, complete sentence.\n\n" +
+      "What counts as 'one fact':\n" +
+      "- ✅ Multiple coupled details about a SINGLE entity " +
+      "(\"Katie is the CEO of Mitzi and a co-founder\")\n" +
+      "- ❌ Two distinct entities (\"User's wife is Emily. They share a Todoist.\") " +
+      "→ make TWO remember() calls\n" +
+      "- ❌ Bio fact + behavior/workflow pattern (\"Has a dog named Stout. " +
+      "Often walks the dog while listening to podcasts.\") → make TWO remember() calls\n" +
+      "- ❌ Multiple distinct preferences/decisions in one call → split\n\n" +
+      "On write, the store searches for near-duplicates and an LLM decides " +
+      "ADD / REPLACE / NOOP (skipped if skip_dedup=true).",
     inputSchema: {
       type: "object",
       properties: {
         content: {
           type: "string",
           description:
-            "A single atomic fact, already formatted as a complete sentence in " +
-            "third person. Split multiple facts into multiple remember() calls.",
+            "A single atomic fact in third person, as a complete sentence. " +
+            "See the rules in this tool's description before calling — bundled " +
+            "details about one entity are fine; mashing multiple entities or " +
+            "bio+behavior together is not.",
         },
         source: {
           type: "string",

--- a/system/instructions.md
+++ b/system/instructions.md
@@ -25,6 +25,8 @@ jpOS has a Qdrant-backed semantic memory store you interact with via the `rememb
 
 If a user message contains multiple facts, make multiple `remember` calls — one fact each, each as a complete sentence in third person.
 
+**Split when in doubt.** Bundled details about a single entity are fine ("Katie is CEO and a co-founder of Mitzi"). What's NOT fine: two distinct entities in one call ("Wife is Emily. We share a Todoist."), or a bio fact mashed with a behavior/workflow pattern ("Has a dog named Stout. Walks the dog while listening to podcasts."). Both cases → make two `remember()` calls.
+
 **After any substantive user input, call `remember` for anything worth carrying forward.** Don't wait for "remember this" — write it if:
 
 - The user shared a preference, opinion, or aesthetic choice


### PR DESCRIPTION
## Why

After the first memory.md migration, a few memories ended up bundling distinct things into one fact:

- ❌ `"User's wife is Emily. They share a Todoist."` — two entities (person + workflow)
- ❌ `"Has a dog named Stout, 5y. Walks the dog while listening to podcasts."` — bio fact + behavior pattern

These hurt recall and future dedup decisions. Recall on "what's the dog's name?" gets noisy with walking-behavior text; future updates to Emily's info get coupled to the Todoist workflow detail.

The agent already knew "one fact per call" from the existing tool description, but was interpreting "fact" loosely (treating "context about one topic" as one fact).

## What

Tightened the wording at the two highest-leverage surfaces:

1. **`src/mcp/memory.ts` — the `remember` tool's MCP description** (read every time the agent considers calling the tool). Added ✅/❌ examples for the specific failure modes:

    ```
    What counts as 'one fact':
    - ✅ Multiple coupled details about a SINGLE entity ("Katie is CEO of Mitzi and a co-founder")
    - ❌ Two distinct entities ("User's wife is Emily. They share a Todoist.") → TWO calls
    - ❌ Bio fact + behavior/workflow ("Has a dog named Stout. Walks the dog while...") → TWO calls
    - ❌ Multiple distinct preferences/decisions in one call → split
    ```

2. **`system/instructions.md`** — one-line "split when in doubt" rule with the same examples, in the broader behavioral system prompt.

## What this does NOT do

- No server-side processing — keeping the storage layer dumb. The dedup step we already have catches the worst multi-fact issues (it'll surface a near-match and the LLM can REPLACE rather than ADD). Adding an extraction LLM call inside `remember()` would re-introduce the kind of coupling we just escaped by dropping mem0.
- Doesn't backfill the existing migration. The current bundled memories stay as-is; if any feel noisy in recall, fix them with `update_memory`. Re-running migration with the tighter prompt is overkill for ~5 sub-optimal entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)